### PR TITLE
Adds in the locale check for index level redirects to work

### DIFF
--- a/app/routes/($locale)._index.tsx
+++ b/app/routes/($locale)._index.tsx
@@ -12,11 +12,6 @@ import {seoPayload} from '~/lib/seo.server';
 export const headers = routeHeaders;
 
 export async function loader({context, params}: LoaderFunctionArgs) {
-  const {data} = await context.pack.query(PAGE_QUERY, {
-    variables: {handle: '/'},
-    cache: context.storefront.CacheLong(),
-  });
-
   const {language, country} = context.storefront.i18n;
 
   if (
@@ -27,6 +22,11 @@ export async function loader({context, params}: LoaderFunctionArgs) {
     // the the locale param must be invalid, send to the 404 page
     throw new Response(null, {status: 404});
   }
+
+  const {data} = await context.pack.query(PAGE_QUERY, {
+    variables: {handle: '/'},
+    cache: context.storefront.CacheLong(),
+  });
 
   if (!data?.page) throw new Response(null, {status: 404});
 

--- a/app/routes/($locale)._index.tsx
+++ b/app/routes/($locale)._index.tsx
@@ -11,11 +11,22 @@ import {seoPayload} from '~/lib/seo.server';
 
 export const headers = routeHeaders;
 
-export async function loader({context}: LoaderFunctionArgs) {
+export async function loader({context, params}: LoaderFunctionArgs) {
   const {data} = await context.pack.query(PAGE_QUERY, {
     variables: {handle: '/'},
     cache: context.storefront.CacheLong(),
   });
+
+  const {language, country} = context.storefront.i18n;
+
+  if (
+    params.locale &&
+    params.locale.toLowerCase() !== `${language}-${country}`.toLowerCase()
+  ) {
+    // If the locale URL param is defined, yet we still are on `EN-US`
+    // the the locale param must be invalid, send to the 404 page
+    throw new Response(null, {status: 404});
+  }
 
   if (!data?.page) throw new Response(null, {status: 404});
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydrogen-starter",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hydrogen-starter",
-      "version": "1.5.5",
+      "version": "1.5.6",
       "dependencies": {
         "@headlessui/react": "^2.0.4",
         "@headlessui/tailwindcss": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydrogen-starter",
   "private": true,
   "sideEffects": false,
-  "version": "1.5.5",
+  "version": "1.5.6",
   "scripts": {
     "dev": "shopify hydrogen dev --port 8080",
     "build": "shopify hydrogen build",


### PR DESCRIPTION
Adds in a check for the `($locale).index.tsx` segment to check the locale to fix issue where going to an unknown page will not be redirected as Remix thinks we are still on the index page in a different locale. 

More info from Remix doc [here](https://remix.run/docs/en/main/file-conventions/routes#optional-segments)