### PR TITLE
Product options bug fix: makes product grouping compare by handle not id

### DIFF
--- a/app/components/Product/ProductOptions/ProductOptionValue/useProductOptionValue.ts
+++ b/app/components/Product/ProductOptions/ProductOptionValue/useProductOptionValue.ts
@@ -100,7 +100,7 @@ export function useProductOptionValue({
   const isColor = name === COLOR_OPTION_NAME;
   const isDisabled = !selectedVariantFromOptions;
   const isFromGrouping = Boolean(
-    selectedVariantFromOptions?.product?.id !== product.id,
+    selectedVariantFromOptions?.product?.handle !== product.handle,
   );
   const isSelected = Boolean(selectedOptionsMap?.[name] === value);
 


### PR DESCRIPTION
There's a bug where all product options are treated as being from groupings, this is because it's comparing by product.id when there's no id on the actual data, only handle. I fixed it by comparing by handle, which should work fine, but maybe it's a better idea to get the actual id in the data instead?