### PR TITLE
Alleivates bug where add to cart Shopify analytics events for new cart lines would not trigger

### DIFF
--- a/app/components/Analytics/useAddToCartAnalytics.ts
+++ b/app/components/Analytics/useAddToCartAnalytics.ts
@@ -28,12 +28,10 @@ export function useAddToCartAnalytics({
 
   const [mounted, setMounted] = useState(false);
   const [previousCartCount, setPreviousCartCount] = useState(0);
-  const [previousCartLines, setPreviousCartLines] = useState<
-    CartLine[] | undefined
-  >(undefined);
-  const [previousCartLinesMap, setPreviousCartLinesMap] = useState<
-    Record<string, CartLine[]> | undefined
-  >(undefined);
+  const [previousCartLinesMap, setPreviousCartLinesMap] = useState<Record<
+    string,
+    CartLine[]
+  > | null>(null);
 
   useEffect(() => {
     if (!mounted) {
@@ -54,8 +52,7 @@ export function useAddToCartAnalytics({
       {},
     );
 
-    if (!previousCartLines || totalQuantity <= previousCartCount) {
-      setPreviousCartLines(cartLines || []);
+    if (totalQuantity <= previousCartCount) {
       setPreviousCartCount(totalQuantity || 0);
       setPreviousCartLinesMap(cartItemsMap || {});
       return;
@@ -141,7 +138,6 @@ export function useAddToCartAnalytics({
       };
       await sendShopifyAnalytics(event);
       if (DEBUG) console.log('sendShopifyAnalytics:add_to_cart', event);
-      setPreviousCartLines(cartLines);
       setPreviousCartCount(totalQuantity);
       setPreviousCartLinesMap(cartItemsMap);
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydrogen-starter",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hydrogen-starter",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "dependencies": {
         "@headlessui/react": "^2.1.2",
         "@headlessui/tailwindcss": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydrogen-starter",
   "private": true,
   "sideEffects": false,
-  "version": "1.6.1",
+  "version": "1.6.2",
   "scripts": {
     "dev": "shopify hydrogen dev --port 8080",
     "build": "shopify hydrogen build",


### PR DESCRIPTION
Removes code from `useAddToCartAnalytics` inadvertently blocking add to cart Shopify Analytics events for new cart lines. Previously, only add to cart events for existing cart lines would trigger.