### PR TITLE
Lock @headlessui/react to stable package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "hydrogen-starter",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hydrogen-starter",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "dependencies": {
-        "@headlessui/react": "^2.1.3",
+        "@headlessui/react": "2.1.2",
         "@headlessui/tailwindcss": "^0.2.1",
         "@pack/client": "^1.0.1",
         "@pack/hydrogen": "^1.0.5",
@@ -2967,9 +2967,9 @@
       }
     },
     "node_modules/@headlessui/react": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.1.3.tgz",
-      "integrity": "sha512-Nt+NlnQbVvMHVZ/QsST6DNyfG8VWqjOYY3eZpp0PrRKpmZw+pzhwQ1F6wtNaW4jnudeC2a5MJC70vbGVcETNIg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.1.2.tgz",
+      "integrity": "sha512-Kb3hgk9gRNRcTZktBrKdHhF3xFhYkca1Rk6e1/im2ENf83dgN54orMW0uSKTXFnUpZOUFZ+wcY05LlipwgZIFQ==",
       "dependencies": {
         "@floating-ui/react": "^0.26.16",
         "@react-aria/focus": "^3.17.1",
@@ -31213,9 +31213,9 @@
       "requires": {}
     },
     "@headlessui/react": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.1.3.tgz",
-      "integrity": "sha512-Nt+NlnQbVvMHVZ/QsST6DNyfG8VWqjOYY3eZpp0PrRKpmZw+pzhwQ1F6wtNaW4jnudeC2a5MJC70vbGVcETNIg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.1.2.tgz",
+      "integrity": "sha512-Kb3hgk9gRNRcTZktBrKdHhF3xFhYkca1Rk6e1/im2ENf83dgN54orMW0uSKTXFnUpZOUFZ+wcY05LlipwgZIFQ==",
       "requires": {
         "@floating-ui/react": "^0.26.16",
         "@react-aria/focus": "^3.17.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydrogen-starter",
   "private": true,
   "sideEffects": false,
-  "version": "1.8.0",
+  "version": "1.8.1",
   "scripts": {
     "dev": "shopify hydrogen dev --port 8080",
     "build": "shopify hydrogen build",
@@ -18,7 +18,7 @@
   ],
   "prettier": "@shopify/prettier-config",
   "dependencies": {
-    "@headlessui/react": "^2.1.3",
+    "@headlessui/react": "2.1.2",
     "@headlessui/tailwindcss": "^0.2.1",
     "@pack/client": "^1.0.1",
     "@pack/hydrogen": "^1.0.5",


### PR DESCRIPTION
Locks `@headlessui/react` to stable package version because latest versions have issue with listbox options not being clickable