### PR TITLE
Fix Article Paths to reflect Shopify

### DIFF
--- a/app/routes/($locale).articles.$handle.tsx
+++ b/app/routes/($locale).articles.$handle.tsx
@@ -1,85 +1,25 @@
-import {useMemo} from 'react';
-import {useLoaderData} from '@remix-run/react';
-import {json} from '@shopify/remix-oxygen';
-import type {LoaderFunctionArgs, MetaArgs} from '@shopify/remix-oxygen';
-import {AnalyticsPageType, getSeoMeta} from '@shopify/hydrogen';
-import {RenderSections} from '@pack/react';
+import { ARTICLE_QUERY } from '~/data/queries';
+import { redirect } from '@shopify/remix-oxygen';
+import type { LoaderFunctionArgs } from '@shopify/remix-oxygen';
 
-import {ARTICLE_QUERY} from '~/data/queries';
-import {getShop, getSiteSettings} from '~/lib/utils';
-import {routeHeaders} from '~/data/cache';
-import {seoPayload} from '~/lib/seo.server';
-
-export const headers = routeHeaders;
-
-export async function loader({params, context, request}: LoaderFunctionArgs) {
-  const {handle} = params;
-  const {data} = await context.pack.query(ARTICLE_QUERY, {
-    variables: {handle},
+export async function loader({ params, context }: LoaderFunctionArgs) {
+  const { locale, handle } = params;
+  const { data } = await context.pack.query(ARTICLE_QUERY, {
+    variables: { handle },
     cache: context.storefront.CacheLong(),
   });
 
-  if (!data.article) throw new Response(null, {status: 404});
+  if (!data || !data.article || !data.article.blog) throw new Response(null, { status: 404 });
 
-  const shop = await getShop(context);
-  const siteSettings = await getSiteSettings(context);
-  const analytics = {pageType: AnalyticsPageType.article};
-  const seo = seoPayload.article({
-    page: data.article,
-    shop,
-    siteSettings,
-    url: request.url,
-  });
+  const blogHandle = data.article.blog.handle;
+  const newPath = locale
+    ? `/${locale}/blogs/${blogHandle}/${handle}`
+    : `/blogs/${blogHandle}/${handle}`;
 
-  return json({
-    analytics,
-    article: data.article,
-    seo,
-    url: request.url,
-  });
+  // Redirect to the new path
+  return redirect(newPath, 301);
 }
 
-export const meta = ({matches}: MetaArgs<typeof loader>) => {
-  return getSeoMeta(...matches.map((match) => (match.data as any).seo));
-};
-
-export default function ArticleRoute() {
-  const {article} = useLoaderData<typeof loader>();
-
-  const atDate =
-    article.firstPublishedAt || article.publishedAt || article.createdAt;
-  const date = useMemo(() => {
-    const options = {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    } as Intl.DateTimeFormatOptions;
-    return new Date(atDate).toLocaleDateString('en-US', options);
-  }, [atDate]);
-
-  return (
-    <div className="py-contained" data-comp={ArticleRoute.displayName}>
-      <section
-        className="px-contained mb-8 flex flex-col items-center gap-3 text-center md:mb-10"
-        data-comp="article-header"
-      >
-        <p className="text-sm md:text-base">
-          {article.author ? `${article.author} | ` : ''}
-          {date}
-        </p>
-
-        <h1 className="text-h2 max-w-[60rem]">{article.title}</h1>
-
-        {article.category && (
-          <p className="btn-text flex h-8 items-center justify-center rounded-full bg-lightGray px-4 text-text">
-            {article.category}
-          </p>
-        )}
-      </section>
-
-      <RenderSections content={article} />
-    </div>
-  );
+export default function RedirectRoute() {
+  return null;
 }
-
-ArticleRoute.displayName = 'ArticleRoute';

--- a/app/routes/($locale).blogs.$blogHandle.$handle.tsx
+++ b/app/routes/($locale).blogs.$blogHandle.$handle.tsx
@@ -1,0 +1,73 @@
+import {useMemo} from 'react';
+import {useLoaderData} from '@remix-run/react';
+import {json} from '@shopify/remix-oxygen';
+import type {LoaderFunctionArgs, MetaArgs} from '@shopify/remix-oxygen';
+import {AnalyticsPageType, getSeoMeta} from '@shopify/hydrogen';
+import {RenderSections} from '@pack/react';
+
+import {ARTICLE_QUERY} from '~/data/queries';
+import {getShop, getSiteSettings} from '~/lib/utils';
+import {routeHeaders} from '~/data/cache';
+import {seoPayload} from '~/lib/seo.server';
+
+export const headers = routeHeaders;
+
+export async function loader({params, context, request}: LoaderFunctionArgs) {
+  const {handle} = params;
+  const {data} = await context.pack.query(ARTICLE_QUERY, {
+    variables: {handle},
+    cache: context.storefront.CacheLong(),
+  });
+
+  if (!data.article) throw new Response(null, {status: 404});
+
+  const shop = await getShop(context);
+  const siteSettings = await getSiteSettings(context);
+  const analytics = {pageType: AnalyticsPageType.article};
+  const seo = seoPayload.article({
+    page: data.article,
+    shop,
+    siteSettings,
+    url: request.url,
+  });
+
+  return json({
+    analytics,
+    article: data.article,
+    seo,
+    url: request.url,
+  });
+}
+
+export const meta = ({data}: MetaArgs) => {
+  return getSeoMeta(data.seo);
+};
+
+export default function ArticleRoute() {
+  const {article} = useLoaderData<typeof loader>();
+
+  const atDate =
+    article.firstPublishedAt || article.publishedAt || article.createdAt;
+  const date = useMemo(() => {
+    const options = {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    } as Intl.DateTimeFormatOptions;
+    return new Date(atDate).toLocaleDateString('en-US', options);
+  }, [atDate]);
+
+  return (
+    <div className="py-contained" data-comp={ArticleRoute.displayName}>
+      <section
+        className="px-contained mb-8 flex flex-col items-center gap-3 text-center md:mb-10"
+        data-comp="article-header"
+      >
+      </section>
+
+      <RenderSections content={article} />
+    </div>
+  );
+}
+
+ArticleRoute.displayName = 'ArticleRoute';

--- a/app/sections/BlogGrid/BlogGrid.tsx
+++ b/app/sections/BlogGrid/BlogGrid.tsx
@@ -50,7 +50,7 @@ export function BlogGrid({cms}: {cms: BlogGridCms}) {
             {filteredArticles.slice(startIndex, endIndex).map((article) => {
               return (
                 <li key={article.id}>
-                  <BlogGridItem article={article} />
+                  <BlogGridItem article={article} blogHandle={blog.handle} />
                 </li>
               );
             })}

--- a/app/sections/BlogGrid/BlogGridItem.tsx
+++ b/app/sections/BlogGrid/BlogGridItem.tsx
@@ -3,7 +3,7 @@ import {useMemo} from 'react';
 import type {Article} from '~/lib/types';
 import {Image, Link} from '~/components';
 
-export function BlogGridItem({article}: {article: Article}) {
+export function BlogGridItem({article, blogHandle}: {article: Article; blogHandle: string}) {
   const atDate =
     article.firstPublishedAt || article.publishedAt || article.createdAt;
   const date = useMemo(() => {
@@ -15,7 +15,7 @@ export function BlogGridItem({article}: {article: Article}) {
     return new Date(atDate).toLocaleDateString('en-US', options);
   }, [atDate]);
 
-  const url = `/articles/${article.handle}`;
+  const url = `/blogs/${blogHandle}/${article.handle}`;
 
   return (
     <div>


### PR DESCRIPTION
Resolves PLT-2705. 

Updates: 
- updated route for articles to be `($locale).blogs.$blogHandle.$handle.tsx` 
- added a redirect from the old route `($locale).articles.$handle.tsx` to the new route 
- updated `BlogGrid` component to point to the correct article paths 

Not 100% on this one, are any other changes required here? Would appreciate your feedback @jeremyagabriel 
After that, I assume we need to submit PRs to all our existing Hydrogen storefronts. 