### PR TITLE
Fix phone number links in markdown

### DIFF
--- a/app/components/Markdown/Markdown.tsx
+++ b/app/components/Markdown/Markdown.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown from 'react-markdown';
 import type {Components} from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
+import { defaultUrlTransform } from 'react-markdown';
 
 interface MarkdownProps {
   centerAllText?: boolean;
@@ -24,7 +25,7 @@ export const Markdown = forwardRef(
       if (url.startsWith('tel:')) {
         return url;
       }
-      return url;
+      return defaultUrlTransform(url);
     };
 
     return (

--- a/app/components/Markdown/Markdown.tsx
+++ b/app/components/Markdown/Markdown.tsx
@@ -19,6 +19,14 @@ export const Markdown = forwardRef(
     const hTextAlign = centerAllText
       ? '[&>h2]:text-center [&>h3]:text-center [&>h4]:text-center [&>h5]:text-center [&>h6]:text-center'
       : '';
+
+    const urlTransform = (url: string) => {
+      if (url.startsWith('tel:')) {
+        return url;
+      }
+      return url;
+    };
+
     return (
       <div
         ref={ref}
@@ -26,6 +34,7 @@ export const Markdown = forwardRef(
       >
         <ReactMarkdown
           remarkPlugins={[remarkGfm, remarkBreaks]}
+          urlTransform={urlTransform}
           components={components}
         >
           {children}


### PR DESCRIPTION
Currently, adding a phone number as a link in markdown results in an empty href. 

![image](https://github.com/user-attachments/assets/8d4453e8-3e08-40c5-87a3-52ecd2d86e11)
![image](https://github.com/user-attachments/assets/127bde53-e735-49f2-b683-6637a3340192)

I added a custom URL transform for phone links, other links are left untouched using the default url transform. 

![image](https://github.com/user-attachments/assets/389ef2f2-e8d5-4d22-ba00-26b6bc5158a2)
![image](https://github.com/user-attachments/assets/28ebb53c-8918-4957-bbd5-7d857322f17e)

Testing page: https://kristyna-packathon-09b86f759877902bd395.o2.myshopify.dev/pages/md-test 