### PR TITLE
Updates Image component for latest Hydrogen versions, fixes add to cart button text shift, adds tel url support for markdown

### DIFF
--- a/app/components/Account/Order/OrderItem.tsx
+++ b/app/components/Account/Order/OrderItem.tsx
@@ -42,7 +42,6 @@ export function OrderItem({item}: {item: OrderLineItem}) {
               : PRODUCT_IMAGE_ASPECT_RATIO
           }
           width="48"
-          isStatic
         />
 
         <div className="flex flex-1 flex-col items-start gap-2">

--- a/app/components/AddToCart/AddToCart.tsx
+++ b/app/components/AddToCart/AddToCart.tsx
@@ -68,7 +68,7 @@ export function AddToCart({
           {buttonText}
         </span>
 
-        {isAdding && !isAdded && (
+        {isAdding && (
           <LoadingDots
             status="Adding to cart"
             withAbsolutePosition
@@ -77,7 +77,7 @@ export function AddToCart({
         )}
 
         {isAdded && (
-          <span aria-live="assertive" role="status">
+          <span aria-live="assertive" className="absolute-center" role="status">
             Added To Cart
           </span>
         )}

--- a/app/components/Cart/CartLine/CartLine.tsx
+++ b/app/components/Cart/CartLine/CartLine.tsx
@@ -44,7 +44,6 @@ export function CartLine({closeCart, line}: CartLineProps) {
               : PRODUCT_IMAGE_ASPECT_RATIO
           }
           width="88"
-          isStatic
           className="bg-offWhite"
         />
       </Link>

--- a/app/components/Cart/CartUpsell/CartUpsellItem.tsx
+++ b/app/components/Cart/CartUpsell/CartUpsellItem.tsx
@@ -52,7 +52,6 @@ export function CartUpsellItem({
               : PRODUCT_IMAGE_ASPECT_RATIO
           }
           width="40"
-          isStatic
         />
       </Link>
 

--- a/app/components/Collection/CollectionFilters/CollectionFilterDropdown/CollectionFilterOption.tsx
+++ b/app/components/Collection/CollectionFilters/CollectionFilterDropdown/CollectionFilterOption.tsx
@@ -115,7 +115,6 @@ export function CollectionFilterOption({
             }}
             aspectRatio="1/1"
             width="24"
-            isStatic
             className="media-fill"
           />
         )}

--- a/app/components/Header/Menu/DesktopMenu.tsx
+++ b/app/components/Header/Menu/DesktopMenu.tsx
@@ -89,7 +89,6 @@ export function DesktopMenu({
                       }}
                       aspectRatio="16/9"
                       width="400"
-                      isStatic
                     />
 
                     <p className="mt-3 text-sm">{caption}</p>

--- a/app/components/Image/Image.tsx
+++ b/app/components/Image/Image.tsx
@@ -5,16 +5,7 @@ import type {AspectRatio} from '~/lib/types';
 
 type ImageProps = React.ComponentProps<typeof HydrogenImage> & {
   aspectRatio?: AspectRatio | undefined;
-  isStatic?: boolean;
   withLoadingAnimation?: boolean;
-};
-
-const getPxWidthNum = (width: string | number | undefined) => {
-  if (!width) return undefined;
-  if (typeof width === 'number') return width;
-  if (width.endsWith('rem')) return Number(width.replace('rem', '')) * 16;
-  if (width.endsWith('em')) return Number(width.replace('em', '')) * 16;
-  return Number(width.replace('px', ''));
 };
 
 export const Image = forwardRef(
@@ -23,22 +14,12 @@ export const Image = forwardRef(
       aspectRatio,
       className,
       data,
-      width: passedWidth,
-      isStatic, // sets only 1 srcSet option that is 3x scale
+      width,
       withLoadingAnimation = true, // adds a loading shimmer animation if data.url is undefined
       ...props
     }: ImageProps,
     ref: React.Ref<HTMLImageElement>,
   ) => {
-    let width = passedWidth;
-    const isRelativeWidth =
-      typeof width === 'string' &&
-      (width.endsWith('%') || width.endsWith('vw'));
-    if (!isRelativeWidth) {
-      width = getPxWidthNum(passedWidth);
-    }
-    const isPxWidth = typeof width === 'number';
-
     return data?.url ? (
       <HydrogenImage
         ref={ref}
@@ -46,31 +27,13 @@ export const Image = forwardRef(
         aspectRatio={aspectRatio}
         width={width}
         className={`bg-offWhite object-cover ${className}`}
-        srcSetOptions={
-          isStatic && isPxWidth
-            ? {
-                intervals: 1,
-                startingWidth: Number(width) * 3,
-                incrementSize: Number(width) * 3,
-                placeholderWidth: Number(width) * 3,
-              }
-            : {
-                intervals: 12,
-                startingWidth: 200,
-                incrementSize: 250,
-                placeholderWidth: 100,
-              }
-        }
         {...props}
       />
     ) : (
       <div
         ref={ref}
         className={`relative overflow-hidden bg-offWhite ${className}`}
-        style={{
-          aspectRatio,
-          width: isPxWidth ? `${width}px` : width || '100%',
-        }}
+        style={{aspectRatio, width}}
       >
         {withLoadingAnimation && <div className="loading-shimmer opacity-60" />}
       </div>

--- a/app/components/Markdown/Markdown.tsx
+++ b/app/components/Markdown/Markdown.tsx
@@ -1,8 +1,8 @@
 import {forwardRef} from 'react';
-import ReactMarkdown from 'react-markdown';
-import type {Components} from 'react-markdown';
+import ReactMarkdown, {defaultUrlTransform} from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
+import type {Components} from 'react-markdown';
 
 interface MarkdownProps {
   centerAllText?: boolean;
@@ -19,6 +19,14 @@ export const Markdown = forwardRef(
     const hTextAlign = centerAllText
       ? '[&>h2]:text-center [&>h3]:text-center [&>h4]:text-center [&>h5]:text-center [&>h6]:text-center'
       : '';
+
+    const urlTransform = (url: string) => {
+      if (url.startsWith('tel:')) {
+        return url;
+      }
+      return defaultUrlTransform(url);
+    };
+
     return (
       <div
         ref={ref}
@@ -26,6 +34,7 @@ export const Markdown = forwardRef(
       >
         <ReactMarkdown
           remarkPlugins={[remarkGfm, remarkBreaks]}
+          urlTransform={urlTransform}
           components={components}
         >
           {children}

--- a/app/components/Product/ProductMedia/ProductMediaThumbnail.tsx
+++ b/app/components/Product/ProductMedia/ProductMediaThumbnail.tsx
@@ -37,7 +37,6 @@ export function ProductMediaThumbnail({
         aspectRatio="1/1"
         width="80"
         loading={index < 6 ? 'eager' : 'lazy'}
-        isStatic
       />
 
       {mediaContentType === 'VIDEO' && (

--- a/app/components/Product/ProductOptions/ProductOptionValue/InnerColorOptionValue.tsx
+++ b/app/components/Product/ProductOptions/ProductOptionValue/InnerColorOptionValue.tsx
@@ -51,7 +51,6 @@ export function InnerColorOptionValue({
           aspectRatio="1/1"
           width="32"
           className="media-fill"
-          isStatic
         />
       )}
 

--- a/app/components/ProductItem/ColorVariantSelector/ColorVariantOption.tsx
+++ b/app/components/ProductItem/ColorVariantSelector/ColorVariantOption.tsx
@@ -52,7 +52,6 @@ export function ColorVariantOption({
             width="24"
             aspectRatio="1/1"
             className="media-fill"
-            isStatic
           />
         )}
 

--- a/app/sections/BuildYourOwnBundle/BYOBAddToCart.tsx
+++ b/app/sections/BuildYourOwnBundle/BYOBAddToCart.tsx
@@ -88,7 +88,7 @@ export function BYOBAddToCart({
         {`Add To Cart${total ? ` - ${total}` : ''}`}
       </span>
 
-      {isAdding && !isAdded && (
+      {isAdding && (
         <LoadingDots
           status="Adding to cart"
           withAbsolutePosition
@@ -97,7 +97,7 @@ export function BYOBAddToCart({
       )}
 
       {isAdded && (
-        <span aria-live="assertive" role="status">
+        <span aria-live="assertive" className="absolute-center" role="status">
           Added To Cart
         </span>
       )}

--- a/app/sections/IconRow/IconRow.tsx
+++ b/app/sections/IconRow/IconRow.tsx
@@ -47,7 +47,6 @@ export function IconRow({cms}: {cms: IconRowCms}) {
                         className="bg-transparent"
                         aspectRatio="1/1"
                         width="48"
-                        isStatic
                       />
                     )}
 

--- a/app/sections/PressSlider/PressSliderThumb.tsx
+++ b/app/sections/PressSlider/PressSliderThumb.tsx
@@ -29,7 +29,6 @@ export function PressSliderThumb({
             className={`bg-transparent transition ${
               isActive ? 'opacity-100' : 'opacity-30'
             }`}
-            isStatic
           />
         )}
       </button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydrogen-starter",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hydrogen-starter",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "dependencies": {
         "@headlessui/react": "2.1.2",
         "@headlessui/tailwindcss": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydrogen-starter",
   "private": true,
   "sideEffects": false,
-  "version": "1.9.0",
+  "version": "1.9.1",
   "scripts": {
     "dev": "shopify hydrogen dev --port 8080",
     "build": "shopify hydrogen build",


### PR DESCRIPTION
- Removes the customization within `Image` component. After recent version updates to `Image` from `@shopify/hydrogen-react`, the custom `srcSetOptions` passed in and the `isStatic` logic is no longer needed. This will address any lower res images becoming visibly blurry after upgrading to latest versions [[commit](https://github.com/packdigital/pack-hydrogen-theme-blueprint/commit/05d460d5a75b756329b4ded913b560eac9345a63)]
- Fixes the "Added To Cart" misalignment in the `AddToCart` button [[commit](https://github.com/packdigital/pack-hydrogen-theme-blueprint/commit/24d37a69d75eee51bb493003de82b60bf5b0c7d7)]
- Adds a url transform for `tel:` links for support in `Markdown` [[commit](https://github.com/packdigital/pack-hydrogen-theme-blueprint/commit/fafbdbf2cccec8c3c3df4aab449513bb2022df70)]