### PR TITLE
Fix article paths without blogs

### DIFF
--- a/app/routes/($locale).articles.$handle.tsx
+++ b/app/routes/($locale).articles.$handle.tsx
@@ -1,21 +1,95 @@
-import {redirect} from '@shopify/remix-oxygen';
-import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';
+import { useMemo } from 'react';
+import { useLoaderData } from '@remix-run/react';
+import { json, redirect } from '@shopify/remix-oxygen';
+import type { LoaderFunctionArgs, MetaArgs } from '@shopify/remix-oxygen';
+import { AnalyticsPageType, getSeoMeta } from '@shopify/hydrogen';
+import { RenderSections } from '@pack/react';
 
-import {ARTICLE_QUERY} from '~/data/queries';
+import { ARTICLE_QUERY } from '~/data/queries';
+import { getShop, getSiteSettings } from '~/lib/utils';
+import { routeHeaders } from '~/data/cache';
+import { seoPayload } from '~/lib/seo.server';
 
-export async function loader({params, context}: LoaderFunctionArgs) {
-  const {locale, handle} = params;
-  const {data} = await context.pack.query(ARTICLE_QUERY, {
-    variables: {handle},
+export const headers = routeHeaders;
+
+export async function loader({ params, context, request }: LoaderFunctionArgs) {
+  const { handle, locale } = params;
+  const { data } = await context.pack.query(ARTICLE_QUERY, {
+    variables: { handle },
     cache: context.storefront.CacheLong(),
   });
 
-  if (!data?.article?.blog) throw new Response(null, {status: 404});
+  if (!data.article) throw new Response(null, { status: 404 });
 
-  const blogHandle = data.article.blog.handle;
-  const blogPath = `/blogs/${blogHandle}/${handle}`;
-  const newPath = locale ? `/${locale}${blogPath}` : blogPath;
+  if (data.article.blog) {
+    // If the article has a blog, redirect to the new path
+    const blogHandle = data.article.blog.handle;
+    const newPath = locale
+      ? `/${locale}/blogs/${blogHandle}/${handle}`
+      : `/blogs/${blogHandle}/${handle}`;
+    return redirect(newPath, 301);
+  } else {
+    // If the article exists but has no blog, don't redirect
+    const shop = await getShop(context);
+    const siteSettings = await getSiteSettings(context);
+    const analytics = { pageType: AnalyticsPageType.article };
+    const seo = seoPayload.article({
+      page: data.article,
+      shop,
+      siteSettings,
+      url: request.url,
+    });
 
-  // Redirect to the new path
-  return redirect(newPath, 301);
+    return json({
+      analytics,
+      article: data.article,
+      seo,
+      url: request.url,
+    });
+  }
 }
+
+export const meta = ({matches}: MetaArgs<typeof loader>) => {
+  return getSeoMeta(...matches.map((match) => (match.data as any).seo));
+};
+
+export default function ArticleRoute() {
+  const { article } = useLoaderData<typeof loader>();
+
+  const atDate =
+    article.firstPublishedAt || article.publishedAt || article.createdAt;
+  const date = useMemo(() => {
+    const options = {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    } as Intl.DateTimeFormatOptions;
+    return new Date(atDate).toLocaleDateString('en-US', options);
+  }, [atDate]);
+
+  return (
+    <div className="py-contained" data-comp={ArticleRoute.displayName}>
+      <section
+        className="px-contained mb-8 flex flex-col items-center gap-3 text-center md:mb-10"
+        data-comp="article-header"
+      >
+        <p className="text-sm md:text-base">
+          {article.author ? `${article.author} | ` : ''}
+          {date}
+        </p>
+
+        <h1 className="text-h2 max-w-[60rem]">{article.title}</h1>
+
+        {article.category && (
+          <p className="btn-text flex h-8 items-center justify-center rounded-full bg-lightGray px-4 text-text">
+            {article.category}
+          </p>
+        )}
+      </section>
+
+      <RenderSections content={article} />
+    </div>
+  );
+}
+
+ArticleRoute.displayName = 'ArticleRoute';


### PR DESCRIPTION
**Previous Behavior:**
- All articles were redirected to the path `blogs/bloghandle/articlehandle`.
- If an article didn't have a blog assigned, navigating to it would result in a 404. 

**Updated Behavior:**
- Articles with an assigned blog continue to be redirected to `blogs/bloghandle/articlehandle`.
- If an article doesn't have a blog assigned, it is no longer redirected. Instead, it remains accessible at its original path `articles/articlehandle`.

This is what we agreed on with Nguyen to ensure articles without blogs assigned to them don't start suddenly 404ing for clients. 