### PR TITLE
Reverts PDP url param set method, adds logic to ignore tracking url params as product options

### DIFF
--- a/app/components/Product/Product.tsx
+++ b/app/components/Product/Product.tsx
@@ -1,9 +1,8 @@
 import {useEffect, useMemo} from 'react';
-import {useSearchParams} from '@remix-run/react';
 import {useProduct} from '@shopify/hydrogen-react';
 
 import {COLOR_OPTION_NAME} from '~/lib/constants';
-import {useSettings} from '~/hooks';
+import {useLocale, useSettings} from '~/hooks';
 import type {SelectedVariant} from '~/lib/types';
 
 import {ProductDetails} from './ProductDetails';
@@ -16,8 +15,8 @@ export function Product({product, initialSelectedVariant}: ProductProps) {
   const {selectedVariant: providerSelectedVariant} = useProduct() as {
     selectedVariant: SelectedVariant;
   };
-  const setSearchParams = useSearchParams()[1];
   const {header, product: productSettings} = useSettings();
+  const {pathPrefix} = useLocale();
 
   const selectedVariant = useMemo(() => {
     /* workaround because selected variant from useProduct hook is momentarily
@@ -39,16 +38,16 @@ export function Product({product, initialSelectedVariant}: ProductProps) {
   useEffect(() => {
     if (product.variants.nodes.length === 1 || !selectedVariant) return;
 
-    const {search} = window.location;
+    const {origin, search} = window.location;
+
     const params = new URLSearchParams(search);
     selectedVariant.selectedOptions?.forEach(({name, value}) => {
       params.set(name, value);
     });
 
-    setSearchParams(params, {
-      preventScrollReset: true,
-      replace: true,
-    });
+    const updatedUrl = `${origin}${pathPrefix}/products/${product.handle}?${params}`;
+
+    window.history.replaceState(window.history.state, '', updatedUrl);
   }, [product.handle, selectedVariant?.id]);
 
   const stickyPromobar =

--- a/app/contexts/GlobalProvider.tsx
+++ b/app/contexts/GlobalProvider.tsx
@@ -3,7 +3,6 @@ import {useCart} from '@shopify/hydrogen-react';
 import type {ReactNode} from 'react';
 
 import type {Action, Dispatch, GlobalContext, GlobalState} from '~/lib/types';
-import {MenuProvider, PromobarProvider, SettingsProvider} from '~/contexts';
 
 const Context = createContext({state: {}, actions: {}} as GlobalContext);
 

--- a/app/routes/($locale).products.$handle.tsx
+++ b/app/routes/($locale).products.$handle.tsx
@@ -47,7 +47,8 @@ export async function loader({params, context, request}: LoaderFunctionArgs) {
 
   // set selected options from the query string
   searchParams.forEach((value, name) => {
-    if (name === 'variant') return;
+    if (name === 'variant' || name === 'srsltid' || name.startsWith('utm_'))
+      return;
     selectedOptions.push({name, value});
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydrogen-starter",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hydrogen-starter",
-      "version": "1.9.6",
+      "version": "1.9.7",
       "dependencies": {
         "@headlessui/react": "^2.1.10",
         "@headlessui/tailwindcss": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydrogen-starter",
   "private": true,
   "sideEffects": false,
-  "version": "1.9.6",
+  "version": "1.9.7",
   "scripts": {
     "dev": "shopify hydrogen dev --port 8080",
     "build": "shopify hydrogen build",


### PR DESCRIPTION
- Reverts the use of `useSearchParams` to update the product page url from release `v1.9.4`. If the product page had a url param that wasn't a product option, e.g. tracking url param, the user would be unable to successfully select any variant other than the first one [[commit](https://github.com/packdigital/pack-hydrogen-theme-blueprint/commit/b26d33d42cab42aa37735247630c1bac5432de4d)] 
- Adds additional check to not include common tracking url parameters as possible product options when a product page first loads [[commit](https://github.com/packdigital/pack-hydrogen-theme-blueprint/commit/7c6bf4bf06b9767279988ae9b9861eb0869f88dc)]