### PR TITLE
Check PACK_SECRET_TOKEN is set

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -73,6 +73,12 @@ export default {
       /**
        * Create Pack client.
        */
+
+      // check if the PACK_SECRET_TOKEN is set
+      if (!env.PACK_SECRET_TOKEN) {
+        throw new Error('PACK_SECRET_TOKEN environment variable is not set');
+      }
+    
       const pack = createPackClient({
         cache,
         waitUntil,


### PR DESCRIPTION
`npx shopify hydrogen env pull` command doesn't pull `PACK_SECRET_TOKEN` env variable if it's set as a secret env in Shopify. 

![image](https://github.com/user-attachments/assets/d5d20acc-f54a-4a84-861d-9a27f5be5386)

This results in a very confusing generic 500 error when trying to access the Customizer on localhost.

![image](https://github.com/user-attachments/assets/9e2a964c-a5a8-414a-a33e-b7d13194b324)

![image](https://github.com/user-attachments/assets/ff9caf6d-8147-4050-bf6d-95bb237dfcca)

I propose we add a check just before creating Pack client to make sure it's set, so we can throw our own error instead. 

![image](https://github.com/user-attachments/assets/3a9896dd-163c-4845-a1f3-cfbfd2fce838)


