### PR TITLE
Fix Scrolling for Anchor Links

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,6 +1,8 @@
+import { useEffect } from 'react';
 import {
   isRouteErrorResponse,
   Outlet,
+  useLocation,
   useMatches,
   useRouteError,
 } from '@remix-run/react';
@@ -157,6 +159,20 @@ export const meta = ({matches}: MetaArgs<typeof loader>) => {
 };
 
 export default function App() {
+  const location = useLocation();
+
+   // scroll to hash on navigation
+   useEffect(() => {
+    if (location.hash) {
+      setTimeout(() => {
+        const element = document.getElementById(location.hash.substring(1));
+        if (element) {
+          element.scrollIntoView({ behavior: 'smooth' });
+        }
+      }, 0);
+    }
+  }, [location]);
+
   return (
     <Document>
       <Outlet />


### PR DESCRIPTION
This update resolves the issue where anchor links require two clicks to navigate to the target section. With this code in place, it scrolls directly to the anchor with a single click.