### PR TITLE
feat: identifies klaviyo email in useMarketingListSubscribe on success

### DIFF
--- a/app/hooks/useMarketingListSubscribe.ts
+++ b/app/hooks/useMarketingListSubscribe.ts
@@ -93,10 +93,14 @@ export function useMarketingListSubscribe({
           setSubmitted(false);
         }, resetTimer);
       }
-      if (fetcher.data.email)
+      if (fetcher.data.email) {
         publish(AnalyticsEvent.CUSTOMER_SUBSCRIBED, {
           email: fetcher.data.email,
         });
+        window.klaviyo?.identify({
+          email: fetcher.data.email,
+        });
+      }
       if (fetcher.data.phone)
         publish(AnalyticsEvent.CUSTOMER_SUBSCRIBED, {
           phone: fetcher.data.phone,

--- a/remix.env.d.ts
+++ b/remix.env.d.ts
@@ -52,6 +52,8 @@ declare global {
     // Fueled
     fueled?: any;
     fueledConfig?: Record<string, any>;
+    // klaviyo
+    klaviyo?: any;
   }
 }
 


### PR DESCRIPTION
@jeremyagabriel  Not sure if this would be the place to add it but it will get overlooked for the next migrations we would need to do to identify emails for klaviyo signup forms

Maybe we should add the klaviyo events in our pack analytics folder?