### PR TITLE
Feat/MobileMenu Products Slider Optional Chaining

### DIFF
--- a/app/components/Header/Menu/MobileMenu.tsx
+++ b/app/components/Header/Menu/MobileMenu.tsx
@@ -148,7 +148,7 @@ export const MobileMenu = memo(
                     return (
                       <SwiperSlide key={index}>
                         <ProductItem
-                          handle={product.handle}
+                          handle={product?.handle}
                           index={index}
                           onClick={handleCloseMobileMenu}
                           swatchesMap={swatchesMap}


### PR DESCRIPTION
This update adds an optional chaining operator on the product object being accessed to set the handle prop value of the ProductItem component used to render the Product Slider portion of the Mobile Menu. This is useful to protect against the edge case where an item exists in the Products Slider section setting list of products but has no product attached/assigned to it. Currently, this scenario will result in an error. With this update, the expression will short-circuit, but will not cause a site crash / server error.