### PR TITLE
Corrects the quantity for add to cart events for all Analytics implementations

### DIFF
--- a/app/components/Analytics/BlotoutEvents/events.ts
+++ b/app/components/Analytics/BlotoutEvents/events.ts
@@ -145,18 +145,22 @@ const addToCartEvent = ({
   try {
     if (debug) logSubscription({data, packEventName});
 
-    const {currentLine} = data;
+    const {currentLine, prevLine} = data;
     if (!currentLine)
       throw new Error('`cart` and/or `currentLine` parameters are missing.');
 
-    const contents = [currentLine].map(edgeTagMapCartLine);
+    const lineAdded = {
+      ...currentLine,
+      quantity: (currentLine.quantity || 1) - (prevLine?.quantity || 0),
+    };
+    const contents = [lineAdded].map(edgeTagMapCartLine);
 
     if (!window.edgetag) throw new Error('`edgetag` is not defined.');
 
     window.edgetag('tag', 'AddToCart', {
       contents,
-      currency: currentLine.cost?.totalAmount?.currencyCode,
-      value: Number(currentLine.cost?.totalAmount?.amount),
+      currency: lineAdded.cost?.totalAmount?.currencyCode,
+      value: Number(lineAdded.cost?.totalAmount?.amount),
     });
 
     if (debug)

--- a/app/components/Analytics/ElevarEvents/events.ts
+++ b/app/components/Analytics/ElevarEvents/events.ts
@@ -370,10 +370,14 @@ const addToCartEvent = ({
   try {
     if (debug) logSubscription({data, analyticsEvent});
 
-    const {cart, currentLine, customer, shop} = data;
+    const {cart, currentLine, customer, prevLine, shop} = data;
     if (!cart || !currentLine)
       throw new Error('`cart` and/or `currentLine` parameters are missing.');
 
+    const lineAdded = {
+      ...currentLine,
+      quantity: (currentLine.quantity || 1) - (prevLine?.quantity || 0),
+    };
     const previousPath = sessionStorage.getItem('PREVIOUS_PATH');
     const list =
       (window.location.pathname.startsWith('/collections') &&
@@ -388,7 +392,7 @@ const addToCartEvent = ({
         currencyCode: cart.cost?.totalAmount?.currencyCode || shop?.currency,
         add: {
           actionField: {list},
-          products: [currentLine].map(mapCartLine(list)),
+          products: [lineAdded].map(mapCartLine(list)),
         },
       },
     };
@@ -409,10 +413,14 @@ const removeFromCartEvent = ({
   try {
     if (debug) logSubscription({data, analyticsEvent});
 
-    const {cart, prevLine, customer, shop} = data;
+    const {cart, currentLine, customer, prevLine, shop} = data;
     if (!cart || !prevLine)
       throw new Error('`cart` and/or `prevLine` parameters are missing.');
 
+    const lineRemoved = {
+      ...prevLine,
+      quantity: (prevLine.quantity || 1) - (currentLine?.quantity || 0),
+    };
     const previousPath = sessionStorage.getItem('PREVIOUS_PATH');
     const list =
       (window.location.pathname.startsWith('/collections') &&
@@ -427,7 +435,7 @@ const removeFromCartEvent = ({
         currencyCode: cart.cost?.totalAmount?.currencyCode || shop?.currency,
         remove: {
           actionField: {list},
-          products: [prevLine].map(mapCartLine(list)),
+          products: [lineRemoved].map(mapCartLine(list)),
         },
       },
     };

--- a/app/components/Analytics/FueledEvents/events.ts
+++ b/app/components/Analytics/FueledEvents/events.ts
@@ -363,10 +363,14 @@ const addToCartEvent = ({
   try {
     if (debug) logSubscription({data, analyticsEvent});
 
-    const {cart, currentLine, customer, shop} = data;
+    const {cart, currentLine, customer, prevLine, shop} = data;
     if (!cart || !currentLine)
       throw new Error('`cart` and/or `currentLine` parameters are missing.');
 
+    const lineAdded = {
+      ...currentLine,
+      quantity: (currentLine.quantity || 1) - (prevLine?.quantity || 0),
+    };
     const previousPath = sessionStorage.getItem('PREVIOUS_PATH');
     const list =
       (window.location.pathname.startsWith('/collections') &&
@@ -380,7 +384,7 @@ const addToCartEvent = ({
         currency_code: cart.cost?.totalAmount?.currencyCode || shop?.currency,
         add: {
           actionField: {list},
-          products: [currentLine].map(mapCartLine(list)),
+          products: [lineAdded].map(mapCartLine(list)),
         },
         cart_id: cart.id?.split('/').pop(),
         cart_total: cart.cost?.totalAmount?.amount || '0.0',
@@ -404,10 +408,14 @@ const removeFromCartEvent = ({
   try {
     if (debug) logSubscription({data, analyticsEvent});
 
-    const {cart, prevLine, customer, shop} = data;
+    const {cart, currentLine, customer, prevLine, shop} = data;
     if (!cart || !prevLine)
       throw new Error('`cart` and/or `prevLine` parameters are missing.');
 
+    const lineRemoved = {
+      ...prevLine,
+      quantity: (prevLine.quantity || 1) - (currentLine?.quantity || 0),
+    };
     const previousPath = sessionStorage.getItem('PREVIOUS_PATH');
     const list =
       (window.location.pathname.startsWith('/collections') &&
@@ -421,7 +429,7 @@ const removeFromCartEvent = ({
         currency_code: cart.cost?.totalAmount?.currencyCode || shop?.currency,
         remove: {
           actionField: {list},
-          products: [prevLine].map(mapCartLine(list)),
+          products: [lineRemoved].map(mapCartLine(list)),
         },
         cart_id: cart.id?.split('/').pop(),
         cart_total: cart.cost?.totalAmount?.amount || '0.0',

--- a/app/components/Analytics/GA4Events/events.ts
+++ b/app/components/Analytics/GA4Events/events.ts
@@ -363,10 +363,14 @@ const addToCartEvent = ({
   try {
     if (debug) logSubscription({data, analyticsEvent});
 
-    const {cart, currentLine, customer, shop} = data;
+    const {cart, currentLine, customer, prevLine, shop} = data;
     if (!cart || !currentLine)
       throw new Error('`cart` and/or `currentLine` parameters are missing.');
 
+    const lineAdded = {
+      ...currentLine,
+      quantity: (currentLine.quantity || 1) - (prevLine?.quantity || 0),
+    };
     const previousPath = sessionStorage.getItem('PREVIOUS_PATH');
     const list =
       (window.location.pathname.startsWith('/collections') &&
@@ -380,7 +384,7 @@ const addToCartEvent = ({
         currency_code: cart.cost?.totalAmount?.currencyCode || shop?.currency,
         add: {
           actionField: {list},
-          products: [currentLine].map(mapCartLine(list)),
+          products: [lineAdded].map(mapCartLine(list)),
         },
         cart_id: cart.id?.split('/').pop(),
         cart_total: cart.cost?.totalAmount?.amount || '0.0',
@@ -404,10 +408,14 @@ const removeFromCartEvent = ({
   try {
     if (debug) logSubscription({data, analyticsEvent});
 
-    const {cart, prevLine, customer, shop} = data;
+    const {cart, currentLine, customer, prevLine, shop} = data;
     if (!cart || !prevLine)
       throw new Error('`cart` and/or `prevLine` parameters are missing.');
 
+    const lineRemoved = {
+      ...prevLine,
+      quantity: (prevLine.quantity || 1) - (currentLine?.quantity || 0),
+    };
     const previousPath = sessionStorage.getItem('PREVIOUS_PATH');
     const list =
       (window.location.pathname.startsWith('/collections') &&
@@ -421,7 +429,7 @@ const removeFromCartEvent = ({
         currency_code: cart.cost?.totalAmount?.currencyCode || shop?.currency,
         remove: {
           actionField: {list},
-          products: [prevLine].map(mapCartLine(list)),
+          products: [lineRemoved].map(mapCartLine(list)),
         },
         cart_id: cart.id?.split('/').pop(),
         cart_total: cart.cost?.totalAmount?.amount || '0.0',

--- a/app/components/Analytics/KlaviyoEvents/events.ts
+++ b/app/components/Analytics/KlaviyoEvents/events.ts
@@ -110,17 +110,21 @@ const addToCartEvent = ({
   try {
     if (debug) logSubscription({data, analyticsEvent});
 
-    const {currentLine, customer} = data;
+    const {currentLine, customer, prevLine} = data;
     if (!currentLine)
       throw new Error('`cart` and/or `currentLine` parameters are missing.');
 
+    const lineAdded = {
+      ...currentLine,
+      quantity: (currentLine.quantity || 1) - (prevLine?.quantity || 0),
+    };
     const previousPath = sessionStorage.getItem('PREVIOUS_PATH');
     const windowPathname = pathWithoutLocalePrefix(window.location.pathname);
     const list =
       (windowPathname.startsWith('/collections') && windowPathname) ||
       (previousPath?.startsWith('/collections') && previousPath) ||
       '';
-    const productProps = mapCartLine(list)(currentLine);
+    const productProps = mapCartLine(list)(lineAdded);
     emitEvent({
       email: customer?.email,
       event: 'Added to Cart',

--- a/app/components/Analytics/MetaPixelEvents/events.ts
+++ b/app/components/Analytics/MetaPixelEvents/events.ts
@@ -97,11 +97,11 @@ const addToCartEvent = ({
   try {
     if (debug) logSubscription({data, analyticsEvent});
 
-    const {cart, currentLine} = data;
+    const {cart, currentLine, prevLine} = data;
     if (!cart || !currentLine)
       throw new Error('`cart` and/or `currentLine` parameters are missing.');
 
-    const {quantity} = currentLine;
+    const quantity = (currentLine.quantity || 1) - (prevLine?.quantity || 0);
     const {product} = currentLine.merchandise;
     const {amount, currencyCode} = currentLine.cost.totalAmount;
 

--- a/app/components/Analytics/TikTokPixelEvents/events.ts
+++ b/app/components/Analytics/TikTokPixelEvents/events.ts
@@ -113,11 +113,11 @@ const addToCartEvent = ({
   try {
     if (debug) logSubscription({data, analyticsEvent});
 
-    const {cart, currentLine, customer} = data;
+    const {cart, currentLine, prevLine} = data;
     if (!cart || !currentLine)
       throw new Error('`cart` and/or `currentLine` parameters are missing.');
 
-    const {quantity} = currentLine;
+    const quantity = (currentLine.quantity || 1) - (prevLine?.quantity || 0);
     const {product} = currentLine.merchandise;
     const {amount, currencyCode} = currentLine.cost.totalAmount;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydrogen-starter",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydrogen-starter",
-      "version": "1.12.2",
+      "version": "1.12.3",
       "dependencies": {
         "@fingerprintjs/botd": "^1.9.1",
         "@headlessui/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydrogen-starter",
   "private": true,
   "sideEffects": false,
-  "version": "1.12.2",
+  "version": "1.12.3",
   "type": "module",
   "scripts": {
     "dev": "shopify hydrogen dev --port 8080",


### PR DESCRIPTION
- Corrects the quantity for "add to cart" and "remove from cart" events for all `Analytics` implementations [[commit](https://github.com/packdigital/pack-hydrogen-theme-blueprint/commit/4dfdd503d4888b5d3a1eeed0b2e92149c41b69e6)]
  - Previously, an ATC (or remove) event would pair the cart line with its current total quantity in the cart, when the appropriate value should have been its current total quantity minus its previous total quantity.