### PR TITLE
Updates header navigation elements to be in DOM at all times for SEO

### DIFF
--- a/app/components/Drawer.tsx
+++ b/app/components/Drawer.tsx
@@ -10,34 +10,37 @@ import {Svg} from '~/components/Svg';
 
 /**
  * Drawer component that opens on user click.
- * @param heading - string. Shown at the top of the drawer.
- * @param open - boolean state. if true opens the drawer.
- * @param onClose - function should set the open state.
- * @param openFrom - right, left
  * @param ariaName - name of drawer for aria-label
- * @param secondHeaderElement - react node. Shown at the top right of the drawer.
  * @param children - react children node.
+ * @param heading - string. Shown at the top of the drawer.
+ * @param onClose - function should set the open state.
+ * @param open - boolean. If true, opens the drawer.
+ * @param openFrom - right, left
+ * @param secondHeaderElement - react node. Shown at the top right of the drawer.
+ * @param unmount - boolean. Whether the content should unmounted or hidden based on the open/closed state.
  */
 
 interface DrawerProps {
+  ariaName?: string;
+  children: React.ReactNode;
   className?: string;
   heading?: React.ReactNode | string;
-  open: boolean;
   onClose: () => void;
+  open: boolean;
   openFrom?: 'right' | 'left';
-  ariaName?: string;
   secondHeaderElement?: React.ReactNode;
-  children: React.ReactNode;
+  unmount?: boolean;
 }
 
 export function Drawer({
+  ariaName = 'drawer',
   className = '',
   heading,
-  open,
   onClose,
+  open,
   openFrom = 'right',
-  ariaName = 'drawer',
   secondHeaderElement,
+  unmount = true,
   children,
 }: DrawerProps) {
   const offScreen = {
@@ -46,10 +49,11 @@ export function Drawer({
   };
 
   return (
-    <Transition appear show={open} as={Fragment}>
+    <Transition appear show={open} as={Fragment} unmount={unmount}>
       <Dialog
         as="div"
         className={`relative z-50 ${className}`}
+        unmount={unmount}
         onClose={onClose}
       >
         {/* Overlay */}
@@ -80,9 +84,11 @@ export function Drawer({
                 leave="transform transition ease-in-out duration-200"
                 leaveFrom="translate-x-0"
                 leaveTo={offScreen[openFrom]}
+                unmount={unmount}
               >
                 <DialogPanel
                   as="aside"
+                  data-comp={Drawer.displayName}
                   className="flex h-[var(--viewport-height)] w-screen flex-col justify-between overflow-hidden bg-background align-middle shadow-xl transition-all md:max-w-[var(--drawer-width)]"
                 >
                   {/* Drawer header */}
@@ -90,6 +96,7 @@ export function Drawer({
                     <button
                       aria-label={`Close ${ariaName}`}
                       className="absolute left-4 top-1/2 -translate-y-1/2"
+                      inert={!open}
                       onClick={onClose}
                       type="button"
                     >

--- a/app/components/Header/Menu/DesktopMenu.tsx
+++ b/app/components/Header/Menu/DesktopMenu.tsx
@@ -2,107 +2,132 @@ import {memo} from 'react';
 
 import {Image} from '~/components/Image';
 import {Link} from '~/components/Link';
+import {useSettings} from '~/hooks';
 
 import type {UseDesktopMenuReturn} from '../useDesktopMenu';
 
 type DesktopMenuProps = Pick<
   UseDesktopMenuReturn,
+  | 'desktopMenuIndex'
   | 'handleDesktopMenuClose'
-  | 'handleDesktopMenuStayOpen'
   | 'handleDesktopMenuHoverOut'
-  | 'desktopMenuContent'
+  | 'handleDesktopMenuStayOpen'
 >;
 
 export const DesktopMenu = memo(
   ({
+    desktopMenuIndex,
     handleDesktopMenuClose,
-    handleDesktopMenuStayOpen,
     handleDesktopMenuHoverOut,
-    desktopMenuContent,
+    handleDesktopMenuStayOpen,
   }: DesktopMenuProps) => {
-    const {imageLinks = [], links = [], mainLink} = {...desktopMenuContent};
-    const hasContent = imageLinks?.length > 0 || links?.length > 0;
+    const {header} = useSettings();
+    const {navItems} = {...header?.menu};
+    const activeMenu =
+      typeof desktopMenuIndex === 'number'
+        ? navItems?.[desktopMenuIndex]
+        : null;
+    const activeMenuHasContent = Boolean(
+      activeMenu &&
+        (activeMenu.imageLinks?.length > 0 ||
+          activeMenu.links?.length > 0 ||
+          !!activeMenu.mainLink?.text),
+    );
 
     return (
       <div
+        data-comp={DesktopMenu.displayName}
         className={`absolute left-0 top-full hidden w-full origin-top border-border bg-background transition duration-200 lg:block ${
-          hasContent ? 'scale-y-100 border-b' : 'scale-y-0'
+          activeMenuHasContent ? 'scale-y-100 border-b' : 'scale-y-0'
         }`}
         onMouseEnter={handleDesktopMenuStayOpen}
         onMouseLeave={handleDesktopMenuHoverOut}
       >
-        {hasContent && (
-          <div className="mx-auto grid max-w-[70rem] grid-cols-[12rem_1fr] gap-5 p-8 md:p-12">
-            <div>
-              <ul className="flex flex-col gap-2">
-                {links?.map(({link}, index) => {
-                  return (
-                    <li key={index}>
-                      <Link
-                        aria-hidden={!hasContent}
-                        aria-label={link?.text}
-                        className="hover-text-underline"
-                        to={link?.url}
-                        newTab={link?.newTab}
-                        onClick={handleDesktopMenuClose}
-                        tabIndex={hasContent ? 0 : -1}
-                        type={link?.type}
-                      >
-                        {link?.text}
-                      </Link>
-                    </li>
-                  );
-                })}
-              </ul>
+        {navItems?.map(({imageLinks, links, mainLink}, index) => {
+          const isActiveMenu = desktopMenuIndex === index;
+          const hasContent =
+            imageLinks?.length > 0 || links?.length > 0 || mainLink?.text;
+          if (!hasContent) return null;
 
-              {mainLink?.text && (
-                <Link
-                  aria-hidden={!hasContent}
-                  aria-label={mainLink.text}
-                  className="btn-primary mt-5"
-                  to={mainLink.url}
-                  newTab={mainLink.newTab}
-                  onClick={handleDesktopMenuClose}
-                  tabIndex={hasContent ? 0 : -1}
-                  type={mainLink.type}
-                >
-                  {mainLink.text}
-                </Link>
+          return (
+            <nav
+              key={index}
+              className={`mx-auto grid max-w-[70rem] grid-cols-[12rem_1fr] gap-5 p-8 md:p-12 ${
+                !isActiveMenu ? 'hidden' : ''
+              }`}
+            >
+              <div>
+                <ul className="flex flex-col gap-2">
+                  {links?.map(({link}, index) => {
+                    return (
+                      <li key={index}>
+                        <Link
+                          aria-label={link?.text}
+                          className="hover-text-underline"
+                          inert={!isActiveMenu}
+                          newTab={link?.newTab}
+                          onClick={handleDesktopMenuClose}
+                          to={link?.url}
+                          type={link?.type}
+                        >
+                          {link?.text}
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
+
+                {mainLink?.text && (
+                  <Link
+                    aria-label={mainLink.text}
+                    className="btn-primary mt-5"
+                    inert={!isActiveMenu}
+                    newTab={mainLink.newTab}
+                    onClick={handleDesktopMenuClose}
+                    to={mainLink.url}
+                    type={mainLink.type}
+                  >
+                    {mainLink.text}
+                  </Link>
+                )}
+              </div>
+
+              {imageLinks?.length > 0 && (
+                <ul className="grid grid-cols-2 gap-5">
+                  {imageLinks.map(({alt, caption, image, link}, index) => {
+                    return (
+                      <li key={index}>
+                        <Link
+                          aria-label={caption}
+                          inert={!isActiveMenu}
+                          newTab={link?.newTab}
+                          onClick={handleDesktopMenuClose}
+                          to={link?.url}
+                          type={link?.type}
+                        >
+                          {isActiveMenu && (
+                            <Image
+                              data={{
+                                altText: image?.altText || alt,
+                                url: image?.url,
+                                width: image?.width,
+                                height: image?.height,
+                              }}
+                              aspectRatio="16/9"
+                              width="400px"
+                            />
+                          )}
+
+                          <p className="mt-3 text-sm">{caption}</p>
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
               )}
-            </div>
-
-            <ul className="grid grid-cols-2 gap-5">
-              {imageLinks?.map(({alt, caption, image, link}, index) => {
-                return (
-                  <li key={index}>
-                    <Link
-                      aria-hidden={!hasContent}
-                      aria-label={caption}
-                      to={link?.url}
-                      newTab={link?.newTab}
-                      onClick={handleDesktopMenuClose}
-                      tabIndex={hasContent ? 0 : -1}
-                      type={link?.type}
-                    >
-                      <Image
-                        data={{
-                          altText: image?.altText || alt,
-                          url: image?.url,
-                          width: image?.width,
-                          height: image?.height,
-                        }}
-                        aspectRatio="16/9"
-                        width="400px"
-                      />
-
-                      <p className="mt-3 text-sm">{caption}</p>
-                    </Link>
-                  </li>
-                );
-              })}
-            </ul>
-          </div>
-        )}
+            </nav>
+          );
+        })}
       </div>
     );
   },

--- a/app/components/Header/Menu/MobileMenu.tsx
+++ b/app/components/Header/Menu/MobileMenu.tsx
@@ -15,15 +15,15 @@ type MobileMenuProps = Pick<
   | 'handleCloseMobileMenu'
   | 'handleMobileSubmenu'
   | 'mobileMenuOpen'
-  | 'mobileSubmenuContent'
+  | 'mobileSubmenuIndex'
 >;
 
 export const MobileMenu = memo(
   ({
     handleCloseMobileMenu,
-    mobileMenuOpen,
-    mobileSubmenuContent,
     handleMobileSubmenu,
+    mobileMenuOpen,
+    mobileSubmenuIndex,
   }: MobileMenuProps) => {
     const {header} = useSettings();
     const {openSearch} = useMenu();
@@ -33,6 +33,16 @@ export const MobileMenu = memo(
       navItems,
       productsSlider,
     } = {...header?.menu};
+    const activeSubmenu =
+      typeof mobileSubmenuIndex === 'number'
+        ? navItems?.[mobileSubmenuIndex]
+        : null;
+    const activeSubmenuHasContent = Boolean(
+      activeSubmenu &&
+        (activeSubmenu.imageLinks?.length > 0 ||
+          activeSubmenu.links?.length > 0 ||
+          !!activeSubmenu.mainLink?.text),
+    );
 
     return (
       <Drawer
@@ -41,11 +51,13 @@ export const MobileMenu = memo(
         onClose={handleCloseMobileMenu}
         open={mobileMenuOpen}
         openFrom="left"
+        unmount={false}
         heading={
           <Link
             aria-label="Go to homepage"
-            to="/"
+            inert={!mobileMenuOpen}
             onClick={handleCloseMobileMenu}
+            to="/"
           >
             <Svg
               className="h-8 text-text"
@@ -59,6 +71,7 @@ export const MobileMenu = memo(
           <button
             aria-label="Open search drawer"
             className="absolute right-4 top-1/2 -translate-y-1/2"
+            inert={!mobileMenuOpen}
             onClick={() => {
               handleCloseMobileMenu();
               openSearch();
@@ -77,7 +90,7 @@ export const MobileMenu = memo(
         <div className="relative w-full flex-1 overflow-x-hidden">
           <div
             className={`scrollbar-hide size-full overflow-y-auto ${
-              mobileSubmenuContent ? 'invisible' : 'visible'
+              activeSubmenuHasContent ? 'invisible' : 'visible'
             }`}
           >
             <nav className="mb-8 flex">
@@ -95,6 +108,7 @@ export const MobileMenu = memo(
                         <button
                           aria-label={item.navItem?.text}
                           className="flex h-14 w-full items-center justify-between gap-5 p-4"
+                          inert={!mobileMenuOpen}
                           onClick={() => handleMobileSubmenu(index)}
                           type="button"
                         >
@@ -113,9 +127,10 @@ export const MobileMenu = memo(
                         <Link
                           aria-label={item.navItem?.text}
                           className="text-nav flex h-14 w-full items-center p-4"
-                          to={item.navItem?.url}
-                          onClick={handleCloseMobileMenu}
+                          inert={!mobileMenuOpen}
                           newTab={item.navItem?.newTab}
+                          onClick={handleCloseMobileMenu}
+                          to={item.navItem?.url}
                           type={item.navItem?.type}
                         >
                           {item.navItem?.text}
@@ -127,7 +142,7 @@ export const MobileMenu = memo(
               </ul>
             </nav>
 
-            {productsSlider?.products?.length > 0 && (
+            {mobileMenuOpen && productsSlider?.products?.length > 0 && (
               <MobileMenuProductsSlider
                 handleCloseMobileMenu={handleCloseMobileMenu}
                 productsSlider={productsSlider}
@@ -135,30 +150,35 @@ export const MobileMenu = memo(
             )}
 
             {additionalLinks?.length > 0 && (
-              <ul className="mb-8 flex flex-col gap-1 px-5">
-                {additionalLinks.map(({link}, index) => {
-                  return (
-                    <li key={index}>
-                      <Link
-                        aria-label={link?.text}
-                        to={link?.url}
-                        onClick={handleCloseMobileMenu}
-                        newTab={link?.newTab}
-                        type={link?.type}
-                      >
-                        {link?.text}
-                      </Link>
-                    </li>
-                  );
-                })}
-              </ul>
+              <nav className="mb-8">
+                <ul className="flex flex-col gap-1 px-5">
+                  {additionalLinks.map(({link}, index) => {
+                    return (
+                      <li key={index}>
+                        <Link
+                          aria-label={link?.text}
+                          inert={!mobileMenuOpen}
+                          newTab={link?.newTab}
+                          onClick={handleCloseMobileMenu}
+                          to={link?.url}
+                          type={link?.type}
+                        >
+                          {link?.text}
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </nav>
             )}
           </div>
 
           <MobileSubmenu
+            activeSubmenuHasContent={activeSubmenuHasContent}
             handleCloseMobileMenu={handleCloseMobileMenu}
             handleMobileSubmenu={handleMobileSubmenu}
-            mobileSubmenuContent={mobileSubmenuContent}
+            mobileSubmenuIndex={mobileSubmenuIndex}
+            navItems={navItems}
           />
         </div>
       </Drawer>

--- a/app/components/Header/Menu/MobileSubmenu.tsx
+++ b/app/components/Header/Menu/MobileSubmenu.tsx
@@ -1,109 +1,133 @@
 import {Image} from '~/components/Image';
 import {Link} from '~/components/Link';
 import {Svg} from '~/components/Svg';
+import type {Settings} from '~/lib/types';
 
 import type {UseMobileMenuReturn} from '../useMobileMenu';
 
 type MobileSubmenuProps = Pick<
   UseMobileMenuReturn,
-  'handleCloseMobileMenu' | 'handleMobileSubmenu' | 'mobileSubmenuContent'
->;
+  'handleCloseMobileMenu' | 'handleMobileSubmenu' | 'mobileSubmenuIndex'
+> & {
+  activeSubmenuHasContent: boolean;
+  navItems: Settings['header']['menu']['navItems'];
+};
 
 export function MobileSubmenu({
+  activeSubmenuHasContent,
   handleCloseMobileMenu,
-  mobileSubmenuContent,
   handleMobileSubmenu,
+  mobileSubmenuIndex,
+  navItems,
 }: MobileSubmenuProps) {
-  const {imageLinks = [], links, mainLink, navItem} = {...mobileSubmenuContent};
-
   return (
     <div
       className={`scrollbar-hide absolute left-0 top-0 z-[1] size-full bg-background ${
-        mobileSubmenuContent ? 'visible' : 'invisible'
+        activeSubmenuHasContent ? 'visible' : 'invisible'
       }`}
     >
-      <div className="scrollbar-hide size-full overflow-y-auto">
-        <button
-          aria-label="Go back to main menu"
-          className="sticky top-0 z-[1] flex h-14 w-full items-center justify-between gap-4 border-b border-b-border bg-background p-4"
-          onClick={() => handleMobileSubmenu(null)}
-          type="button"
-        >
-          <Svg
-            className="w-5"
-            src="/svgs/arrow-left.svg#arrow-left"
-            title="Arrow Left"
-            viewBox="0 0 24 24"
-          />
+      {navItems?.map(({imageLinks, links, mainLink, navItem}, index) => {
+        const isActiveSubmenu = mobileSubmenuIndex === index;
+        const hasContent =
+          imageLinks?.length > 0 || links?.length > 0 || mainLink?.text;
+        if (!hasContent) return null;
 
-          <h3 className="text-nav flex-1 text-left">{navItem?.text}</h3>
-        </button>
-
-        <div className="px-4 pt-5">
-          <ul className="mb-8 flex flex-col gap-2">
-            {links?.map(({link}, index) => {
-              return (
-                <li key={index}>
-                  <Link
-                    aria-label={link?.text}
-                    className="hover-text-underline"
-                    to={link?.url}
-                    newTab={link?.newTab}
-                    onClick={handleCloseMobileMenu}
-                    type={link?.type}
-                  >
-                    {link?.text}
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
-
-          {mainLink?.text && (
-            <Link
-              aria-label={mainLink.text}
-              className="btn-primary mb-8"
-              to={mainLink.url}
-              newTab={mainLink.newTab}
-              onClick={handleCloseMobileMenu}
-              type={mainLink.type}
+        return (
+          <nav
+            className={`scrollbar-hide size-full overflow-y-auto ${
+              !isActiveSubmenu ? 'hidden' : ''
+            }`}
+            key={index}
+          >
+            <button
+              aria-label="Go back to main menu"
+              className="sticky top-0 z-[1] flex h-14 w-full items-center justify-between gap-4 border-b border-b-border bg-background p-4"
+              inert={!isActiveSubmenu}
+              onClick={() => handleMobileSubmenu(null)}
+              type="button"
             >
-              {mainLink.text}
-            </Link>
-          )}
+              <Svg
+                className="w-5"
+                src="/svgs/arrow-left.svg#arrow-left"
+                title="Arrow Left"
+                viewBox="0 0 24 24"
+              />
 
-          {imageLinks?.length > 0 && (
-            <ul className="mb-8 flex flex-col gap-5">
-              {imageLinks.map(({alt, caption, image, link}, index) => {
-                return (
-                  <li key={index}>
-                    <Link
-                      aria-label={caption}
-                      to={link?.url}
-                      newTab={link?.newTab}
-                      onClick={handleCloseMobileMenu}
-                      type={link?.type}
-                    >
-                      <Image
-                        data={{
-                          altText: image?.altText || alt,
-                          url: image?.url,
-                          width: image?.width,
-                          height: image?.height,
-                        }}
-                        aspectRatio="16/9"
-                        sizes="(min-width: 768px) 400px, 100vw"
-                      />
+              <h3 className="text-nav flex-1 text-left">{navItem?.text}</h3>
+            </button>
 
-                      <p className="mt-3 text-sm">{caption}</p>
-                    </Link>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </div>
-      </div>
+            <div className="px-4 pt-5">
+              <ul className="mb-8 flex flex-col gap-2">
+                {links?.map(({link}, index) => {
+                  return (
+                    <li key={index}>
+                      <Link
+                        aria-label={link?.text}
+                        className="hover-text-underline"
+                        inert={!isActiveSubmenu}
+                        newTab={link?.newTab}
+                        onClick={handleCloseMobileMenu}
+                        to={link?.url}
+                        type={link?.type}
+                      >
+                        {link?.text}
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+
+              {mainLink?.text && (
+                <Link
+                  aria-label={mainLink.text}
+                  className="btn-primary mb-8"
+                  inert={!isActiveSubmenu}
+                  newTab={mainLink.newTab}
+                  onClick={handleCloseMobileMenu}
+                  to={mainLink.url}
+                  type={mainLink.type}
+                >
+                  {mainLink.text}
+                </Link>
+              )}
+
+              {imageLinks?.length > 0 && (
+                <ul className="mb-8 flex flex-col gap-5">
+                  {imageLinks.map(({alt, caption, image, link}, index) => {
+                    return (
+                      <li key={index}>
+                        <Link
+                          aria-label={caption}
+                          inert={!isActiveSubmenu}
+                          newTab={link?.newTab}
+                          onClick={handleCloseMobileMenu}
+                          to={link?.url}
+                          type={link?.type}
+                        >
+                          {isActiveSubmenu && (
+                            <Image
+                              data={{
+                                altText: image?.altText || alt,
+                                url: image?.url,
+                                width: image?.width,
+                                height: image?.height,
+                              }}
+                              aspectRatio="16/9"
+                              sizes="(min-width: 768px) 400px, 100vw"
+                            />
+                          )}
+
+                          <p className="mt-3 text-sm">{caption}</p>
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          </nav>
+        );
+      })}
     </div>
   );
 }

--- a/app/components/Header/Navigation/Navigation.tsx
+++ b/app/components/Header/Navigation/Navigation.tsx
@@ -17,20 +17,20 @@ type NavigationProps = Pick<
 > &
   Pick<
     UseDesktopMenuReturn,
+    | 'desktopMenuIndex'
     | 'handleDesktopMenuClose'
     | 'handleDesktopMenuHoverIn'
     | 'handleDesktopMenuHoverOut'
-    | 'desktopMenuContent'
   >;
 
 export const Navigation = memo(
   ({
+    desktopMenuIndex,
     handleCloseMobileMenu,
-    handleOpenMobileMenu,
     handleDesktopMenuClose,
     handleDesktopMenuHoverIn,
     handleDesktopMenuHoverOut,
-    desktopMenuContent,
+    handleOpenMobileMenu,
     mobileMenuOpen,
   }: NavigationProps) => {
     const customer = useCustomer();
@@ -68,8 +68,7 @@ export const Navigation = memo(
           <nav className="hidden h-full lg:flex">
             <ul className="flex">
               {navItems?.map((item, index) => {
-                const isHovered =
-                  item.navItem?.text === desktopMenuContent?.navItem?.text;
+                const isHovered = index === desktopMenuIndex;
 
                 return (
                   <li key={index} className="flex">

--- a/app/components/Header/useDesktopMenu.ts
+++ b/app/components/Header/useDesktopMenu.ts
@@ -1,19 +1,12 @@
 import {
   useCallback,
   // useEffect,
-  useMemo,
   useState,
 } from 'react';
 
-import {
-  // useBodyScrollLock,
-  // useMenu,
-  useSettings,
-} from '~/hooks';
-import type {Settings} from '~/lib/types';
+// import {useBodyScrollLock, useMenu} from '~/hooks';
 
 export interface UseDesktopMenuReturn {
-  desktopMenuContent: Settings['header']['menu']['navItems'][number] | null;
   desktopMenuIndex: number | null;
   /* Desktop menu based on hover ----------------------------------------------- */
   handleDesktopMenuClose: () => void;
@@ -36,8 +29,6 @@ export interface UseDesktopMenuReturn {
  */
 
 export function useDesktopMenu(): UseDesktopMenuReturn {
-  const {header} = useSettings();
-  const {navItems} = {...header?.menu};
   const [desktopMenuIndex, setDesktopMenuIndex] = useState<number | null>(null);
 
   // /* Additional hooks for desktop menu based on click ------------------------- */
@@ -47,12 +38,6 @@ export function useDesktopMenu(): UseDesktopMenuReturn {
   //   null,
   // );
   // /* -------------------------------------------------------------------------- */
-
-  const desktopMenuContent = useMemo(() => {
-    return typeof desktopMenuIndex === 'number'
-      ? navItems?.[desktopMenuIndex] || null
-      : null;
-  }, [desktopMenuIndex, navItems]);
 
   /* Desktop menu based on hover ----------------------------------------------- */
   const clearUnHoverTimer = useCallback(() => {
@@ -118,7 +103,6 @@ export function useDesktopMenu(): UseDesktopMenuReturn {
 
   return {
     desktopMenuIndex,
-    desktopMenuContent,
     /* Desktop menu based on hover --------------------------------------------- */
     handleDesktopMenuClose,
     handleDesktopMenuStayOpen,

--- a/app/components/Header/useMobileMenu.ts
+++ b/app/components/Header/useMobileMenu.ts
@@ -1,20 +1,17 @@
 import {useCallback, useState} from 'react';
 
-import type {Settings} from '~/lib/types';
-import {useMenu, useSettings} from '~/hooks';
+import {useMenu} from '~/hooks';
 
 export interface UseMobileMenuReturn {
   handleOpenMobileMenu: () => void;
   handleCloseMobileMenu: () => void;
   handleMobileSubmenu: (index: number | null) => void;
   mobileMenuOpen: boolean;
-  mobileSubmenuContent: Settings['header']['menu']['navItems'][number] | null;
+  mobileSubmenuIndex: number | null;
 }
 
 export function useMobileMenu(): UseMobileMenuReturn {
   const {mobileMenuOpen, openMobileMenu, closeMobileMenu} = useMenu();
-  const {header} = useSettings();
-  const {navItems} = {...header?.menu};
 
   const [mobileSubmenuIndex, setMobileSubmenuIndex] = useState<number | null>(
     null,
@@ -38,9 +35,6 @@ export function useMobileMenu(): UseMobileMenuReturn {
     handleCloseMobileMenu,
     handleMobileSubmenu,
     mobileMenuOpen,
-    mobileSubmenuContent:
-      typeof mobileSubmenuIndex === 'number'
-        ? navItems?.[mobileSubmenuIndex] || null
-        : null,
+    mobileSubmenuIndex,
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydrogen-starter",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydrogen-starter",
-      "version": "1.12.4",
+      "version": "1.12.5",
       "dependencies": {
         "@fingerprintjs/botd": "^1.9.1",
         "@headlessui/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydrogen-starter",
   "private": true,
   "sideEffects": false,
-  "version": "1.12.4",
+  "version": "1.12.5",
   "type": "module",
   "scripts": {
     "dev": "shopify hydrogen dev --port 8080",


### PR DESCRIPTION
- In both `DesktopMenu` and `MobileMenu`, all header navigation items are mapped out to allow all links to be available on the DOM at all times for proper SEO crawling [[commit](https://github.com/packdigital/pack-hydrogen-theme-blueprint/commit/f936a8b37c2c80d3768fbf6db485c400090f672c)]
  - Sets menus to `hidden` opposed to unmounting
  - Adds `inert` attribute to all interactable elements to turn off visibility to e-readers when menu is hidden
  - Removes `desktopMenuContent` from `useDesktopMenu` and `mobileSubmenuContent` from `useMobileMenu`
  - Adds `unmount` prop to `Drawer` component to pass into `@headlessui/react` components to determine whether the content is unmounted or hidden based on the open/closed state