### PR TITLE
feat: skips force locale redirect if preview is enabled

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -105,7 +105,10 @@ export async function loader({context, request}: LoaderFunctionArgs) {
    * Redirect to the correct locale if the buyer's country is different from the
    * current locale. Occurs only once per cookie session
    */
-  if (storefront.i18n.country !== oxygen.buyer.country) {
+  if (
+    storefront.i18n.country !== oxygen.buyer.country &&
+    !isPreviewModeEnabled
+  ) {
     const redirectedLink = await redirectLinkToBuyerLocale({context, request});
     if (redirectedLink)
       return redirect(redirectedLink.to, redirectedLink.options);


### PR DESCRIPTION
This prevents users from redirecting to their current locale, but not the store's main locale when preview is enabled. 

Users who are not from US are getting redirected to a market where not a lot of products are available, which is causing server errors in the customizer. This also fixes country selector since the customizer can't read the redirect cookie