### PR TITLE
feat: updates loadscript to append script to a react ref

### DIFF
--- a/app/hooks/useLoadScript.ts
+++ b/app/hooks/useLoadScript.ts
@@ -1,3 +1,4 @@
+import type {RefObject} from 'react';
 import {useState, useEffect} from 'react';
 
 const SCRIPTS_LOADED: Record<string, Promise<boolean>> = {};
@@ -7,7 +8,7 @@ export function loadScript(
       `data-${string}`,
       any
     >,
-  placement?: 'head' | 'body' | null,
+  placement?: 'head' | 'body' | RefObject<HTMLElement | null> | null,
 ): Promise<boolean> {
   const {id, innerHTML, src, type, onload, onerror, ...rest} = {
     ...attributes,
@@ -44,7 +45,14 @@ export function loadScript(
         onerror(e);
       }
     };
-    if (placement === 'head') {
+    // checks if placement is react ref
+    if (
+      placement != null &&
+      typeof placement === 'object' &&
+      'current' in placement
+    ) {
+      placement?.current?.appendChild(script);
+    } else if (placement === 'head') {
       document.head.appendChild(script);
     } else {
       document.body.appendChild(script);


### PR DESCRIPTION
there are some 3rd party scripts that uses script as a reference to inject a widget after the `<script />` element. This allows a new option to append script to a specific ref instead of placing script in a head or body. This gives users more control on where to place script if `useLoadScript` is used in a pack section