### PR TITLE
Fix | RTE `<a />` lose `target="_blank"`

### DIFF
--- a/app/components/RichText.tsx
+++ b/app/components/RichText.tsx
@@ -11,21 +11,6 @@ export const RichText = forwardRef(
     {centerAllText, className = '', children}: RichTextProps,
     ref: React.Ref<HTMLDivElement> | undefined,
   ) => {
-    const [sanitizedHtml, setSanitizedHtml] = useState(
-      typeof children === 'string' ? children : '',
-    );
-
-    // Client-side only sanitization
-    useEffect(() => {
-      if (typeof children !== 'string') return;
-      import('dompurify').then((DOMPurify) => {
-        const clean = DOMPurify.default.sanitize(children, {
-          USE_PROFILES: {html: true},
-        });
-        setSanitizedHtml(clean);
-      });
-    }, [children]);
-
     const pTextAlign = centerAllText ? '[&>p]:text-center' : '';
     const hTextAlign = centerAllText
       ? '[&>h2]:text-center [&>h3]:text-center [&>h4]:text-center [&>h5]:text-center [&>h6]:text-center'
@@ -35,7 +20,9 @@ export const RichText = forwardRef(
       <div
         ref={ref}
         className={`mx-auto flex flex-col [&>:first-child]:mt-0 [&>:last-child]:mb-0 [&_a]:underline [&_h1]:mb-6 [&_h1]:text-center [&_h2]:mb-5 [&_h2]:mt-8 [&_h3]:mb-4 [&_h3]:mt-6 [&_h4]:my-4 [&_h5]:mb-4 [&_h5]:mt-2 [&_h6]:mb-4 [&_li>p]:mb-0 [&_li]:mb-2 [&_ol>li]:list-decimal [&_ol]:mb-4 [&_ol]:pl-8 [&_p]:mb-4 [&_table]:relative [&_table]:mb-4 [&_table]:w-full [&_table]:table-fixed [&_table]:border-collapse [&_table]:overflow-x-auto [&_table]:border [&_table]:border-border [&_td]:border [&_td]:border-border [&_td]:p-3 [&_td]:text-center [&_td]:align-top [&_th]:border [&_th]:border-border [&_th]:px-2 [&_th]:py-1.5 [&_thead]:bg-neutralLightest [&_ul>li]:list-disc [&_ul]:mb-4 [&_ul]:pl-8 ${pTextAlign} ${hTextAlign} ${className}`}
-        dangerouslySetInnerHTML={{__html: sanitizedHtml}}
+        dangerouslySetInnerHTML={{
+          __html: typeof children === 'string' ? children : '',
+        }}
       />
     );
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@shopify/remix-oxygen": "^2.0.12",
         "country-region-data": "^3.1.0",
         "crypto-js": "^4.2.0",
-        "dompurify": "^3.2.4",
         "fast-xml-parser": "^4.5.0",
         "graphql": "^16.10.0",
         "hex-to-rgba": "^2.0.1",
@@ -9081,14 +9080,6 @@
       "version": "0.5.16",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/dompurify": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.5.tgz",
-      "integrity": "sha512-mLPd29uoRe9HpvwP2TxClGQBzGXeEC/we/q+bFlmPPmj2p2Ugl3r6ATu/UU1v77DXNcehiBg9zsr1dREyA/dJQ==",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
     },
     "node_modules/dot-case": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@shopify/remix-oxygen": "^2.0.12",
     "country-region-data": "^3.1.0",
     "crypto-js": "^4.2.0",
-    "dompurify": "^3.2.4",
     "fast-xml-parser": "^4.5.0",
     "graphql": "^16.10.0",
     "hex-to-rgba": "^2.0.1",


### PR DESCRIPTION
The RichText component no longer uses DOMPurify for HTML sanitization since it's unnecessary in our SSR architecture.

- Our CMS is the source of truth for content - we control the creation and validation of HTML before it's stored
- Content is server-side rendered (SSR) and delivered as pre-sanitized HTML
- Client-side sanitization adds unnecessary overhead without security benefits in this context
- The risk of XSS is mitigated at the content creation/storage level rather than runtime

Since we control the entire content pipeline from authoring to delivery, the attack vector for XSS that DOMPurify protects against doesn't exist in our SSR implementation. The content is already trusted when rendered.

For SSR applications, security best practices suggest sanitizing content at the source/storage level rather than at each render, which our architecture accomplishes.