### PR TITLE
fix: product route loaders if preview and admin is enabled

### DIFF
--- a/app/routes/($locale).api.product.tsx
+++ b/app/routes/($locale).api.product.tsx
@@ -79,7 +79,7 @@ export async function loader({request, context}: LoaderFunctionArgs) {
         ADMIN_PRODUCT_ITEM_QUERY,
         {variables: {handle}, cache: admin.CacheShort()},
       );
-      if (!adminProduct) return;
+      if (!adminProduct) return {product};
       product = normalizeAdminProduct(adminProduct);
     }
   }

--- a/app/routes/($locale).products.$handle.tsx
+++ b/app/routes/($locale).products.$handle.tsx
@@ -76,7 +76,7 @@ export async function loader({params, context, request}: LoaderFunctionArgs) {
         ADMIN_PRODUCT_QUERY,
         {variables: {handle}, cache: admin.CacheShort()},
       );
-      if (!adminProduct) return;
+      if (!adminProduct) throw new Response(null, {status: 404});
       queriedProduct = normalizeAdminProduct(adminProduct);
       productStatus = adminProduct.status;
     }


### PR DESCRIPTION
![Screenshot 2025-05-05 at 10 53 12 AM](https://github.com/user-attachments/assets/d0b28c02-1079-42ad-8627-5211ac9603dc)

Getting this error if admin and customizer preview is enabled. Loaders need to return any value when querying products that dont exist