### PR TITLE
fix: disables key by default from useFetchers that are more likely to…

### DIFF
--- a/app/hooks/product/useProductByHandle.ts
+++ b/app/hooks/product/useProductByHandle.ts
@@ -18,10 +18,13 @@ import {useLocale} from '~/hooks';
 export function useProductByHandle(
   handle: string | undefined | null = '',
   fetchOnMount = true,
+  addKeyIdentifier = false,
 ): Product | null {
   const {pathPrefix} = useLocale();
   const fetcher = useFetcher<{product: Product}>({
-    key: `product-by-handle:${handle}:${pathPrefix}`,
+    key: addKeyIdentifier
+      ? `product-by-handle:${handle}:${pathPrefix}`
+      : undefined,
   });
 
   useEffect(() => {

--- a/app/hooks/product/useProductRecommendations.ts
+++ b/app/hooks/product/useProductRecommendations.ts
@@ -23,10 +23,13 @@ export function useProductRecommendations(
   productId = '',
   intent: ProductRecommendationIntent = 'RELATED', // 'COMPLEMENTARY' | 'RELATED'
   fetchOnMount = true,
+  addKeyIdentifier = false,
 ): Product[] | null {
   const {pathPrefix} = useLocale();
   const fetcher = useFetcher<{productRecommendations: Product[]}>({
-    key: `product-recommendations:${productId}${intent}:${pathPrefix}`,
+    key: addKeyIdentifier
+      ? `product-recommendations:${productId}${intent}:${pathPrefix}`
+      : undefined,
   });
 
   useEffect(() => {

--- a/app/hooks/product/useProductsByIds.ts
+++ b/app/hooks/product/useProductsByIds.ts
@@ -18,10 +18,13 @@ import {useLocale} from '~/hooks';
 export function useProductsByIds(
   ids: string[] = [],
   fetchOnMount = true,
+  addKeyIdentifier = false,
 ): Product[] {
   const {pathPrefix} = useLocale();
   const fetcher = useFetcher<{products: Product[]}>({
-    key: `products-by-ids:${ids.join(',')}:${pathPrefix}`,
+    key: addKeyIdentifier
+      ? `products-by-ids:${ids.join(',')}:${pathPrefix}`
+      : undefined,
   });
 
   const idsString = JSON.stringify(ids);

--- a/app/hooks/useArticles.ts
+++ b/app/hooks/useArticles.ts
@@ -20,10 +20,13 @@ export function useArticles(
   handle: string | undefined | null = '',
   limit: number | undefined | null = 3,
   fetchOnMount = true,
+  addKeyIdentifier = false,
 ) {
   const {pathPrefix} = useLocale();
   const fetcher = useFetcher<{articles: Article[]}>({
-    key: `articles-by-blog-handle:${handle}:${pathPrefix}`,
+    key: addKeyIdentifier
+      ? `articles-by-blog-handle:${handle}:${pathPrefix}`
+      : undefined,
   });
 
   useEffect(() => {

--- a/app/hooks/useCollectionByHandle.ts
+++ b/app/hooks/useCollectionByHandle.ts
@@ -29,10 +29,13 @@ export function useCollectionByHandle(
   handle: string | undefined | null = '',
   params?: Params,
   fetchOnMount = true,
+  addKeyIdentifier = false,
 ): Collection | null {
   const {pathPrefix} = useLocale();
   const fetcher = useFetcher<{collection: Collection}>({
-    key: `collection-by-handle:${handle}:${pathPrefix}`,
+    key: addKeyIdentifier
+      ? `collection-by-handle:${handle}:${pathPrefix}`
+      : undefined,
   });
 
   useEffect(() => {


### PR DESCRIPTION
Data is lost when passing new params to useFetcher if fetcher contains key. Since some components such as Product Tabbed Slider updates the fetcher with a new handle is passed, a new key is added to that useFetcher which loses its data because it will unmount on a new key. Providing a key should be optional and only be used if that fetcher will remain mounted and if you want to reference that data from a different component

https://pack-digital.slack.com/archives/C07MH8ZSQ8G/p1748625283280349