### PR TITLE
fix: Multipass error: CryptoJS.SHA256 is not a function

### DIFF
--- a/app/lib/multipass/multipassify.server.ts
+++ b/app/lib/multipass/multipassify.server.ts
@@ -1,6 +1,8 @@
 import snake_case from 'snakecase-keys';
 import CryptoJS from 'crypto-js/core';
 import aes from 'crypto-js/aes';
+import SHA256 from 'crypto-js/sha256';
+import HmacSHA256 from 'crypto-js/hmac-sha256';
 
 import type {MultipassCustomer} from './multipass.types';
 
@@ -23,7 +25,7 @@ export class Multipassify {
     this.BLOCK_SIZE = 16;
 
     // Hash the secret
-    const digest = CryptoJS.SHA256(secret);
+    const digest = SHA256(secret);
 
     // create the encryption and signing keys
     this.encryptionKey = CryptoJS.lib.WordArray.create(
@@ -108,7 +110,7 @@ export class Multipassify {
 
   // signs the encrypted customer data
   private sign(encrypted: CryptoJS.lib.WordArray) {
-    return CryptoJS.HmacSHA256(encrypted, this.signingKey);
+    return HmacSHA256(encrypted, this.signingKey);
   }
 
   // Decrypts the customer data from a multipass token

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,8 @@ export default defineConfig({
         'cookie',
         'crypto-js/aes',
         'crypto-js/core',
+        'crypto-js/sha256',
+        'crypto-js/hmac-sha256',
         'debug',
         'fast-deep-equal',
         'fast-xml-parser',


### PR DESCRIPTION
Was getting this error using CryptoJS.SHA256 to create an authenticated signature for a vendor and also tested that multipass doesn't work either. 

Here's an example of what I had to update recently to use that function
https://github.com/packdigital/aloha-collection-hydrogen/commit/57936843d2663ff3ff3789fb37c9b3abc27966f1