### PR TITLE
Adds 301 Shopify Redirects in collection and product route

### DIFF
--- a/app/routes/($locale).collections.$handle.tsx
+++ b/app/routes/($locale).collections.$handle.tsx
@@ -5,11 +5,16 @@ import {
   AnalyticsPageType,
   getPaginationVariables,
   getSeoMeta,
+  storefrontRedirect,
 } from '@shopify/hydrogen';
 import {RenderSections} from '@pack/react';
 import type {LoaderFunctionArgs, MetaArgs} from '@shopify/remix-oxygen';
-import type {ProductCollectionSortKeys} from '@shopify/hydrogen/storefront-api-types';
+import type {
+  ProductCollectionSortKeys as ProductCollectionSortKeysType,
+  Collection as CollectionType,
+} from '@shopify/hydrogen/storefront-api-types';
 
+import type {Page} from '~/lib/types';
 import {Collection} from '~/components/Collection';
 import {COLLECTION_QUERY} from '~/data/graphql/storefront/collection';
 import {COLLECTION_PAGE_QUERY} from '~/data/graphql/pack/collection-page';
@@ -75,7 +80,15 @@ export async function loader({params, context, request}: LoaderFunctionArgs) {
     getShop(context),
   ]);
 
-  if (!collection) throw new Response(null, {status: 404});
+  if (!collection) {
+    const redirect = await storefrontRedirect({request, storefront});
+
+    if (redirect?.status === 301) {
+      return redirect;
+    }
+
+    throw new Response(null, {status: 404});
+  }
 
   const analytics = {
     pageType: AnalyticsPageType.collection,
@@ -105,8 +118,13 @@ export const meta = ({matches}: MetaArgs<typeof loader>) => {
 };
 
 export default function CollectionRoute() {
-  const {activeFilterValues, collection, collectionPage} =
-    useLoaderData<typeof loader>();
+  const {activeFilterValues, collection, collectionPage} = useLoaderData<
+    typeof loader
+  >() as {
+    activeFilterValues: ActiveFilterValue[];
+    collection: CollectionType;
+    collectionPage: Page;
+  };
   const {isCartReady} = useGlobal();
 
   // determines if default collection heading should be shown

--- a/app/routes/($locale).collections.$handle.tsx
+++ b/app/routes/($locale).collections.$handle.tsx
@@ -10,7 +10,7 @@ import {
 import {RenderSections} from '@pack/react';
 import type {LoaderFunctionArgs, MetaArgs} from '@shopify/remix-oxygen';
 import type {
-  ProductCollectionSortKeys as ProductCollectionSortKeysType,
+  ProductCollectionSortKeys,
   Collection as CollectionType,
 } from '@shopify/hydrogen/storefront-api-types';
 
@@ -83,7 +83,7 @@ export async function loader({params, context, request}: LoaderFunctionArgs) {
   if (!collection) {
     const redirect = await storefrontRedirect({request, storefront});
 
-    if (redirect?.status === 301) {
+    if (redirect.status === 301) {
       return redirect;
     }
 

--- a/app/routes/($locale).products.$handle.tsx
+++ b/app/routes/($locale).products.$handle.tsx
@@ -1,6 +1,11 @@
 import {useLoaderData} from '@remix-run/react';
 import {ProductProvider} from '@shopify/hydrogen-react';
-import {Analytics, AnalyticsPageType, getSeoMeta} from '@shopify/hydrogen';
+import {
+  Analytics,
+  AnalyticsPageType,
+  getSeoMeta,
+  storefrontRedirect,
+} from '@shopify/hydrogen';
 import {RenderSections} from '@pack/react';
 import type {LoaderFunctionArgs, MetaArgs} from '@shopify/remix-oxygen';
 import type {ShopifyAnalyticsProduct} from '@shopify/hydrogen';
@@ -20,7 +25,11 @@ import {Product} from '~/components/Product';
 import {routeHeaders} from '~/data/cache';
 import {seoPayload} from '~/lib/seo.server';
 import {useGlobal, useProductWithGrouping} from '~/hooks';
-import type {ProductWithInitialGrouping} from '~/lib/types';
+import type {
+  Page,
+  ProductWithInitialGrouping,
+  SelectedVariant,
+} from '~/lib/types';
 
 export const headers = routeHeaders;
 
@@ -86,7 +95,13 @@ export async function loader({params, context, request}: LoaderFunctionArgs) {
     }
   }
 
-  if (!queriedProduct) throw new Response(null, {status: 404});
+  if (!queriedProduct) {
+    const redirect = await storefrontRedirect({request, storefront});
+    if (redirect?.status === 301) {
+      return redirect;
+    }
+    throw new Response(null, {status: 404});
+  }
 
   let grouping = undefined;
   let groupingProducts = undefined;
@@ -159,7 +174,11 @@ export default function ProductRoute() {
     product: initialProduct,
     productPage,
     selectedVariant: initialSelectedVariant,
-  } = useLoaderData<typeof loader>();
+  } = useLoaderData<typeof loader>() as {
+    product: ProductWithInitialGrouping;
+    productPage: Page;
+    selectedVariant: SelectedVariant;
+  };
   const {isCartReady} = useGlobal();
   const product = useProductWithGrouping(initialProduct);
 

--- a/app/routes/($locale).products.$handle.tsx
+++ b/app/routes/($locale).products.$handle.tsx
@@ -97,7 +97,7 @@ export async function loader({params, context, request}: LoaderFunctionArgs) {
 
   if (!queriedProduct) {
     const redirect = await storefrontRedirect({request, storefront});
-    if (redirect?.status === 301) {
+    if (redirect.status === 301) {
       return redirect;
     }
     throw new Response(null, {status: 404});


### PR DESCRIPTION
since our `<Link />` component has `reloadDocument` set to `false`, we need to add shopify's storefront redirects in for collection and product routes for client side navigation. The `storefrontRedirect` set in `server.ts` only works on page load