### PR TITLE
Swiper Skeleton, adds redirect logic to each route, misc additional RR7 migration

### DIFF
--- a/app/components/ProductItem/ProductItemMedia/ProductItemMedia.tsx
+++ b/app/components/ProductItem/ProductItemMedia/ProductItemMedia.tsx
@@ -11,6 +11,7 @@ import type {ProductWithStatus} from '~/lib/types';
 import type {ProductItemMediaProps} from '../ProductItem.types';
 
 import {ProductItemVideo} from './ProductItemVideo';
+import {ProductItemSkeleton} from '../ProductItemSkeleton';
 import {useProductItemMedia} from './useProductItemMedia';
 
 export function ProductItemMedia({
@@ -98,11 +99,7 @@ export function ProductItemMedia({
       )}
 
       {/* loading shimmer */}
-      {!primaryMedia && (
-        <div className="relative size-full overflow-hidden">
-          <div className="loading-shimmer" />
-        </div>
-      )}
+      {!primaryMedia && <ProductItemSkeleton />}
 
       {(selectedProduct as ProductWithStatus)?.status === 'DRAFT' && (
         <ProductDraftMediaOverlay />

--- a/app/components/ProductItem/ProductItemSkeleton.tsx
+++ b/app/components/ProductItem/ProductItemSkeleton.tsx
@@ -1,0 +1,20 @@
+import {PRODUCT_IMAGE_ASPECT_RATIO} from '~/lib/constants';
+
+export function ProductItemSkeleton() {
+  return (
+    <div className="w-full animate-pulse">
+      <div
+        className="bg-neutralLightest relative overflow-hidden"
+        style={{aspectRatio: PRODUCT_IMAGE_ASPECT_RATIO}}
+      />
+
+      <div className="w-full max-w-[280px] relative overflow-hidden bg-neutralLightest h-6 mt-3" />
+
+      <div className="w-20 relative overflow-hidden bg-neutralLightest h-5 mt-1" />
+
+      <div className="w-8 relative overflow-hidden bg-neutralLightest h-5 mt-1" />
+    </div>
+  );
+}
+
+ProductItemSkeleton.displayName = 'ProductItemSkeleton';

--- a/app/components/ProductItem/index.ts
+++ b/app/components/ProductItem/index.ts
@@ -1,1 +1,2 @@
 export {ProductItem} from './ProductItem';
+export {ProductItemSkeleton} from './ProductItemSkeleton';

--- a/app/components/SwiperSkeleton.tsx
+++ b/app/components/SwiperSkeleton.tsx
@@ -1,0 +1,82 @@
+import clsx from 'clsx';
+
+interface Breakpoint {
+  slidesPerView: number;
+  spaceBetween: number;
+  slidesOffsetBefore: number;
+}
+
+interface Breakpoints {
+  mobile: Breakpoint;
+  tablet: Breakpoint;
+  desktop: Breakpoint;
+}
+
+export function SwiperSkeleton({
+  breakpoints,
+  children, // Skeleton of each slide
+  className = '',
+}: {
+  breakpoints: Breakpoints;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={clsx('w-full overflow-hidden', className)}>
+      {/* Mobile */}
+      <SwiperBreakpointSkeleton className="md:hidden" {...breakpoints.mobile}>
+        {children}
+      </SwiperBreakpointSkeleton>
+
+      {/* Tablet */}
+      <SwiperBreakpointSkeleton
+        className="max-md:hidden lg:hidden"
+        {...breakpoints.tablet}
+      >
+        {children}
+      </SwiperBreakpointSkeleton>
+
+      {/* Desktop */}
+      <SwiperBreakpointSkeleton
+        className="max-lg:hidden"
+        {...breakpoints.desktop}
+      >
+        {children}
+      </SwiperBreakpointSkeleton>
+    </div>
+  );
+}
+
+SwiperSkeleton.displayName = 'SwiperSkeleton';
+
+function SwiperBreakpointSkeleton({
+  children,
+  className = '',
+  spaceBetween,
+  slidesOffsetBefore,
+  slidesPerView,
+}: {
+  children: React.ReactNode;
+  className?: string;
+} & Breakpoint) {
+  return (
+    <ul
+      className={clsx('flex', className)}
+      style={{
+        gap: `${spaceBetween}px`,
+        paddingLeft: `${slidesOffsetBefore}px`,
+      }}
+    >
+      {[...new Array(Math.ceil(slidesPerView))].map((_, index) => {
+        const width = `calc((100% - ${slidesOffsetBefore}px - ${spaceBetween * (slidesPerView - 1)}px) / ${slidesPerView})`;
+        return (
+          <li key={index} style={{width, minWidth: width}}>
+            {children}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+SwiperBreakpointSkeleton.displayName = 'SwiperBreakpointSkeleton';

--- a/app/components/TilesSlider/TilesSlider.tsx
+++ b/app/components/TilesSlider/TilesSlider.tsx
@@ -3,7 +3,7 @@ import {Swiper, SwiperSlide} from 'swiper/react';
 import clsx from 'clsx';
 import type {SwiperClass} from 'swiper/react';
 
-import {Spinner} from '~/components/Animations';
+import {SwiperSkeleton} from '~/components/SwiperSkeleton';
 import type {MediaCms} from '~/lib/types';
 
 import {TilesSliderTile} from './TilesSliderTile';
@@ -41,6 +41,27 @@ export const TilesSlider = forwardRef(
   ) => {
     const [swiper, setSwiper] = useState<SwiperClass | null>(null);
 
+    const breakpoints = {
+      mobile: {
+        slidesPerView: tilesPerViewMobile,
+        slidesOffsetBefore: 16,
+        slidesOffsetAfter: 16,
+        spaceBetween: 16,
+      },
+      tablet: {
+        slidesPerView: tilesPerViewTablet,
+        slidesOffsetBefore: 32,
+        slidesOffsetAfter: 32,
+        spaceBetween: 20,
+      },
+      desktop: {
+        slidesPerView: tilesPerViewDesktop,
+        slidesOffsetBefore: 0,
+        slidesOffsetAfter: 0,
+        spaceBetween: 20,
+      },
+    };
+
     const isGridOnDesktop = tiles?.length === tilesPerViewDesktop;
 
     return tiles?.length > 0 ? (
@@ -55,23 +76,13 @@ export const TilesSlider = forwardRef(
           <Swiper
             grabCursor
             onSwiper={setSwiper}
-            slidesOffsetAfter={16}
-            slidesOffsetBefore={16}
-            slidesPerView={tilesPerViewMobile}
-            spaceBetween={16}
+            slidesOffsetAfter={breakpoints.mobile.slidesOffsetAfter}
+            slidesOffsetBefore={breakpoints.mobile.slidesOffsetBefore}
+            slidesPerView={breakpoints.mobile.slidesPerView}
+            spaceBetween={breakpoints.mobile.spaceBetween}
             breakpoints={{
-              768: {
-                slidesPerView: tilesPerViewTablet,
-                slidesOffsetBefore: 32,
-                slidesOffsetAfter: 32,
-                spaceBetween: 20,
-              },
-              1024: {
-                slidesPerView: tilesPerViewDesktop,
-                slidesOffsetBefore: 0,
-                slidesOffsetAfter: 0,
-                spaceBetween: 20,
-              },
+              768: breakpoints.tablet,
+              1024: breakpoints.desktop,
             }}
           >
             {swiper &&
@@ -91,9 +102,12 @@ export const TilesSlider = forwardRef(
           </Swiper>
 
           {!swiper && (
-            <div className="flex min-h-[25rem] items-center justify-center">
-              <Spinner width="32" />
-            </div>
+            <SwiperSkeleton breakpoints={breakpoints}>
+              <div className="animate-pulse">
+                <div className={clsx('bg-neutralLightest', aspectRatio)} />
+                <div className="mt-4 w-[150px] h-[29px] md:h-8 bg-neutralLightest" />
+              </div>
+            </SwiperSkeleton>
           )}
         </div>
 

--- a/app/lib/products.server.ts
+++ b/app/lib/products.server.ts
@@ -18,7 +18,12 @@ import {getProductGroupings, normalizeAdminProduct} from '~/lib/utils';
 import {SHOPPABLE_SOCIAL_VIDEO_SECTION_KEY} from '~/sections/ShoppableSocialVideo';
 import {PRODUCT_SECTION_KEY} from '~/sections/Product';
 import {MODAL_PRODUCT_URL_PARAM} from '~/lib/constants';
-import type {Group, Page, ProductWithInitialGrouping} from '~/lib/types';
+import type {
+  Group,
+  Page,
+  ProductsMap,
+  ProductWithInitialGrouping,
+} from '~/lib/types';
 
 export const getSelectedProductOptions = async ({
   handle,
@@ -292,7 +297,7 @@ export const getProductsMapForPage = async ({
   const {admin, pack} = context;
   const isPreviewModeEnabled = pack.isPreviewModeEnabled();
 
-  const productsMap: Record<string, Product> = {};
+  const productsMap: ProductsMap = {};
   const sectionsByKey = page.sections?.nodes?.reduce(
     (acc: Record<string, Record<string, any>[]>, section) => {
       return {

--- a/app/lib/seo.server.ts
+++ b/app/lib/seo.server.ts
@@ -245,7 +245,7 @@ function product({
 }: {
   product: ProductRequiredFields;
   selectedVariant: SelectedVariantRequiredFields;
-  page: Page;
+  page?: Page;
   shop: Shop;
   siteSettings: RootSiteSettings;
   url: Request['url'];
@@ -522,7 +522,7 @@ function page({
   shop,
   siteSettings,
 }: {
-  page: Page;
+  page?: Page;
   shop: Shop;
   siteSettings: RootSiteSettings;
 }): SeoConfig {

--- a/app/lib/types/product.types.ts
+++ b/app/lib/types/product.types.ts
@@ -17,6 +17,8 @@ export type ParsedMetafields = Record<string, Metafield | null>;
 
 export type MetafieldIdentifier = {namespace?: string; key: string};
 
+export type ProductsMap = Record<string, Product>;
+
 export interface OptionWithGroups {
   name: string;
   optionValues: ProductOptionValue[];

--- a/app/lib/utils/pack.utils.ts
+++ b/app/lib/utils/pack.utils.ts
@@ -31,7 +31,7 @@ export const getPage = async ({
   }: {
     accumulatedPage: Page | null;
     cursor: string | null;
-  }): Promise<Page> => {
+  }): Promise<Page | undefined> => {
     const {data} = await pack.query(query, {
       variables: {
         handle,
@@ -42,7 +42,7 @@ export const getPage = async ({
       cache: storefront.CacheLong(),
     });
 
-    if (!data?.[pageKey]) throw new Response(null, {status: 404});
+    if (!data?.[pageKey]) return undefined;
 
     const {nodes = [], pageInfo} = {...data[pageKey].sections};
     const combinedSections = {

--- a/app/routes/$.tsx
+++ b/app/routes/$.tsx
@@ -1,10 +1,14 @@
+import type {LoaderFunctionArgs} from '@shopify/remix-oxygen';
+
 /**
  * This is a catch-all route to redirect url's to 404 that do not match any
  * defined route
  */
 
-export async function loader() {
-  throw new Response(null, {status: 404});
+export async function loader({request}: LoaderFunctionArgs) {
+  throw new Response(`${new URL(request.url).pathname} not found`, {
+    status: 404,
+  });
 }
 
 export default function Route404() {

--- a/app/routes/($locale).account.login.multipass.tsx
+++ b/app/routes/($locale).account.login.multipass.tsx
@@ -1,4 +1,4 @@
-import {data as dataWithOptions, redirect} from '@shopify/remix-oxygen';
+import {redirect} from '@shopify/remix-oxygen';
 import type {
   ActionFunctionArgs,
   LoaderFunctionArgs,
@@ -137,7 +137,7 @@ export async function action({request, context}: ActionFunctionArgs) {
       }
 
       // success, return token, url
-      return dataWithOptions(
+      return Response.json(
         {data: {...data, error: null}},
         {
           status: 200,
@@ -175,7 +175,7 @@ export async function action({request, context}: ActionFunctionArgs) {
 }
 
 function handleMethodNotAllowed() {
-  return dataWithOptions(
+  return Response.json(
     {
       data: null,
       error: 'Method not allowed.',
@@ -188,7 +188,7 @@ function handleMethodNotAllowed() {
 }
 
 function handleOptionsPreflight(origin: string) {
-  return dataWithOptions(null, {
+  return Response.json(null, {
     status: 204,
     headers: getCorsHeaders(origin),
   });
@@ -220,7 +220,7 @@ async function handleLoggedOutResponse(options: {
 
   // For example, checkoutDomain `checkout.hydrogen.shop` or `shop.example.com` or `{shop}.myshopify.com`.
   const logOutUrl = `https://${checkoutDomain}/account/logout?return_url=${encodedCheckoutUrl}&step=contact_information`;
-  return {data: {url: logOutUrl}, error: null};
+  return Response.json({data: {url: logOutUrl}, error: null});
 }
 
 /*
@@ -251,7 +251,7 @@ function notLoggedInResponse(options: NotLoggedInResponseType) {
   }
 
   // Always return the original URL.
-  return {data: {url}, error};
+  return Response.json({data: {url}, error});
 }
 
 function getCorsHeaders(origin: string): {[key: string]: string} {

--- a/app/routes/($locale).api.redirect.tsx
+++ b/app/routes/($locale).api.redirect.tsx
@@ -1,4 +1,4 @@
-import {data as dataWithOptions, redirect} from '@shopify/remix-oxygen';
+import {redirect} from '@shopify/remix-oxygen';
 import type {ActionFunctionArgs} from '@shopify/remix-oxygen';
 
 export async function action({request}: ActionFunctionArgs) {
@@ -15,7 +15,7 @@ export async function action({request}: ActionFunctionArgs) {
   } catch (error) {}
 
   if (!to)
-    return dataWithOptions({errors: ['Missing `to` in body']}, {status: 400});
+    return Response.json({errors: ['Missing `to` in body']}, {status: 400});
 
   return status ? redirect(to, {status, headers}) : redirect(to, {headers});
 }

--- a/app/sections/BuildYourOwnBundle/BYOBProductItem/BYOBProductItemMedia.tsx
+++ b/app/sections/BuildYourOwnBundle/BYOBProductItem/BYOBProductItemMedia.tsx
@@ -75,9 +75,7 @@ export function BYOBProductItemMedia({
 
       {/* loading shimmer */}
       {!primaryMedia && (
-        <div className="relative size-full overflow-hidden">
-          <div className="loading-shimmer" />
-        </div>
+        <div className="size-full bg-neutralLightest animate-pulse" />
       )}
     </div>
   );

--- a/app/sections/ImageTiles/ImageTiles.tsx
+++ b/app/sections/ImageTiles/ImageTiles.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import type {SwiperClass} from 'swiper/react';
 
 import {Container} from '~/components/Container';
-import {Spinner} from '~/components/Animations';
+import {SwiperSkeleton} from '~/components/SwiperSkeleton';
 
 import type {ImageTilesCms} from './ImageTiles.types';
 import {ImageTile} from './ImageTile';
@@ -27,6 +27,27 @@ export function ImageTiles({cms}: {cms: ImageTilesCms}) {
   } = {...section};
 
   const [swiper, setSwiper] = useState<SwiperClass | null>(null);
+
+  const breakpoints = {
+    mobile: {
+      slidesPerView: tilesPerViewMobile,
+      slidesOffsetBefore: 16,
+      slidesOffsetAfter: 16,
+      spaceBetween: 16,
+    },
+    tablet: {
+      slidesPerView: tilesPerViewTablet,
+      slidesOffsetBefore: 32,
+      slidesOffsetAfter: 32,
+      spaceBetween: 20,
+    },
+    desktop: {
+      slidesPerView: tilesPerViewDesktop,
+      slidesOffsetBefore: 0,
+      slidesOffsetAfter: 0,
+      spaceBetween: 20,
+    },
+  };
 
   const maxWidthClass = fullWidth
     ? 'max-w-none'
@@ -63,23 +84,13 @@ export function ImageTiles({cms}: {cms: ImageTilesCms}) {
                 <Swiper
                   grabCursor
                   onSwiper={setSwiper}
-                  slidesOffsetAfter={16}
-                  slidesOffsetBefore={16}
-                  slidesPerView={tilesPerViewMobile}
-                  spaceBetween={16}
+                  slidesOffsetAfter={breakpoints.mobile.slidesOffsetAfter}
+                  slidesOffsetBefore={breakpoints.mobile.slidesOffsetBefore}
+                  slidesPerView={breakpoints.mobile.slidesPerView}
+                  spaceBetween={breakpoints.mobile.spaceBetween}
                   breakpoints={{
-                    768: {
-                      slidesPerView: tilesPerViewTablet,
-                      slidesOffsetBefore: 32,
-                      slidesOffsetAfter: 32,
-                      spaceBetween: 20,
-                    },
-                    1024: {
-                      slidesPerView: tilesPerViewDesktop,
-                      slidesOffsetBefore: 0,
-                      slidesOffsetAfter: 0,
-                      spaceBetween: 20,
-                    },
+                    768: breakpoints.tablet,
+                    1024: breakpoints.desktop,
                   }}
                 >
                   {swiper &&
@@ -97,9 +108,14 @@ export function ImageTiles({cms}: {cms: ImageTilesCms}) {
                 </Swiper>
 
                 {!swiper && (
-                  <div className="flex min-h-[25rem] items-center justify-center">
-                    <Spinner width="32" />
-                  </div>
+                  <SwiperSkeleton breakpoints={breakpoints}>
+                    <div
+                      className={clsx(
+                        'bg-neutralLightest animate-pulse',
+                        aspectRatio,
+                      )}
+                    />
+                  </SwiperSkeleton>
                 )}
               </div>
 

--- a/app/sections/Product/Product.tsx
+++ b/app/sections/Product/Product.tsx
@@ -5,13 +5,13 @@ import {useLoaderData} from '@remix-run/react';
 import {Container} from '~/components/Container';
 import {Product as ProductComponent} from '~/components/Product';
 import {useProductByHandle} from '~/hooks';
-import type {loader} from '~/routes/($locale).pages.$handle';
+import type {ProductsMap} from '~/lib/types';
 
 import type {ProductCms} from './Product.types';
 import {Schema} from './Product.schema';
 
 export function Product({cms}: {cms: ProductCms}) {
-  const {productsMap} = useLoaderData<typeof loader>();
+  const {productsMap} = useLoaderData<{productsMap: ProductsMap}>();
   const cmsProductHandle = cms.product?.handle;
   const loaderProduct = productsMap[cmsProductHandle];
   const fetchedProduct = useProductByHandle(

--- a/app/sections/ShoppableSocialVideo/ShoppableSocialVideo.tsx
+++ b/app/sections/ShoppableSocialVideo/ShoppableSocialVideo.tsx
@@ -8,7 +8,7 @@ import clsx from 'clsx';
 import {RichText} from '~/components/RichText';
 import {Svg} from '~/components/Svg';
 import {useRootLoaderData, useColorSwatches} from '~/hooks';
-import type {loader} from '~/routes/($locale).pages.$handle';
+import type {ProductsMap} from '~/lib/types';
 
 import {ShoppableSocialVideoProductCard} from './ShoppableSocialVideoProductCard';
 import {
@@ -22,7 +22,7 @@ import type {ShoppableSocialVideoCms} from './ShoppableSocialVideo.types';
 export function ShoppableSocialVideo({cms}: {cms: ShoppableSocialVideoCms}) {
   const ref = useRef(null);
   const {isPreviewModeEnabled} = useRootLoaderData();
-  const {productsMap} = useLoaderData<typeof loader>();
+  const {productsMap} = useLoaderData<{productsMap: ProductsMap}>();
   const swatchesMap = useColorSwatches();
 
   const [activeIndex, setActiveIndex] = useState(0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydrogen-starter",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydrogen-starter",
-      "version": "1.13.3",
+      "version": "1.13.4",
       "dependencies": {
         "@fingerprintjs/botd": "^1.9.1",
         "@headlessui/react": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydrogen-starter",
   "private": true,
   "sideEffects": false,
-  "version": "1.13.3",
+  "version": "1.13.4",
   "type": "module",
   "scripts": {
     "dev": "shopify hydrogen dev --port 8080",


### PR DESCRIPTION
New:
- Adds `SwiperSkeleton` component that is used with sections `ProductsSlider`, `TilesSlider`, `TabbedTilesSlider`, and `ImageTiles` in replacement of a spinner [[commit](https://github.com/packdigital/pack-hydrogen-theme-blueprint/commit/237debe441726ef4950154e24ea3f9de62c26030)] [[commit](https://github.com/packdigital/pack-hydrogen-theme-blueprint/pull/102/commits/9f959ef104e2600a97bfca40ace39e19b8f10430)]
  - Forms a placeholder for the slides while swiper is initializing based on the mobile, tablet, and desktop breakpoint values passed into Swiper
  - Accepts the intended skeleton for each slide as the child of the component
  - Adds `ProductItemSkeleton` component

Migration:
- Updates the returns from missed resource routes to return with `Response.json()` (as prep for React Router 7), as an addendum from the main update in [release v1.13.3](https://github.com/packdigital/pack-hydrogen-theme-blueprint/releases/tag/v1.13.3) [[commit](https://github.com/packdigital/pack-hydrogen-theme-blueprint/pull/102/commits/a59ec29e86f19b1fcab81ca8f6ff4d79694bea9e)]

Improvement:
- Integrates Hydrogen's `storefrontRedirect` into each route to account for redirects (set in Shopify) upon navigation [[commit](https://github.com/packdigital/pack-hydrogen-theme-blueprint/commit/518ceca892b98bffcf809f1021ec9be851be3d72)]
  - Previously, because `storefrontRedirect` was only set in `server.ts`, redirects only applied on page load or refresh. Now upon Remix navigation, each route will check if a redirect exists if the page does not exist
  - Note, redirects intended for a page not on one of the main routes, e.g. `...com/some-page`, will still not redirect on page navigation, only page reload
  - Updates `useLoaderData` types as needed
