### PR TITLE
Fixes broken Blog page, fixes broken eslint plugins, redefines media-fill class used with most primary images

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -7,7 +7,6 @@ module.exports = {
     'plugin:hydrogen/recommended',
     'plugin:hydrogen/typescript',
     'plugin:tailwindcss/recommended',
-    'plugin:prettier/recommended',
   ],
   overrides: [
     {

--- a/app/components/Collection/CollectionFilters/CollectionFilterDropdown/CollectionFilterOption.tsx
+++ b/app/components/Collection/CollectionFilters/CollectionFilterDropdown/CollectionFilterOption.tsx
@@ -128,7 +128,7 @@ export function CollectionFilterOption({
 
         <div
           className={clsx(
-            'media-fill rounded-[1px] border-white transition-[border-width] duration-100',
+            'absolute inset-0 rounded-[1px] border-white transition-[border-width] duration-100',
             isActive ? 'border-0 md:border-0' : 'border-0',
           )}
         />
@@ -137,7 +137,7 @@ export function CollectionFilterOption({
           src="/svgs/checkmark.svg#checkmark"
           viewBox="0 0 24 24"
           className={clsx(
-            'pointer-events-none w-6 transition md:w-5',
+            'pointer-events-none absolute left-1/2 top-1/2 w-4 -translate-x-1/2 -translate-y-1/2 transition md:w-3',
             checkmarkColor,
             isActive ? 'opacity-100' : 'opacity-0',
           )}

--- a/app/components/Collection/CollectionPromoTile.tsx
+++ b/app/components/Collection/CollectionPromoTile.tsx
@@ -39,7 +39,7 @@ export function CollectionPromoTile({tile}: CollectionPromoTileProps) {
             {hasVideo && (
               <video
                 autoPlay
-                className="absolute inset-0 size-full object-cover"
+                className="media-fill"
                 controls={false}
                 loop
                 muted

--- a/app/components/Product/ProductOptions/ProductOptionValue/InnerColorOptionValue.tsx
+++ b/app/components/Product/ProductOptions/ProductOptionValue/InnerColorOptionValue.tsx
@@ -62,7 +62,7 @@ export function InnerColorOptionValue({
 
       <div
         className={clsx(
-          'media-fill rounded-[50%] border-white transition-[border-width] duration-100',
+          'absolute inset-0 size-full rounded-[50%] border-white transition-[border-width] duration-100',
           isSelected ? 'border-[3px]' : 'border-0',
         )}
       />

--- a/app/components/ProductItem/ColorVariantSelector/ColorVariantOption.tsx
+++ b/app/components/ProductItem/ColorVariantSelector/ColorVariantOption.tsx
@@ -51,7 +51,7 @@ export function ColorVariantOption({
 
         <div
           className={clsx(
-            'media-fill rounded-[50%] border-white transition-[border-width] duration-100',
+            'absolute inset-0 size-full rounded-[50%] border-white transition-[border-width] duration-100',
             isActive ? 'border-2' : 'border-0',
           )}
         />

--- a/app/components/ProductItem/ProductItemMedia/ProductItemMedia.tsx
+++ b/app/components/ProductItem/ProductItemMedia/ProductItemMedia.tsx
@@ -78,7 +78,7 @@ export function ProductItemMedia({
       )}
 
       {inView && hoverMedia && (
-        <div className="hidden opacity-0 transition duration-300 md:block md:group-hover/media:opacity-100">
+        <div className="absolute inset-0 hidden size-full opacity-0 transition duration-300 md:block md:group-hover/media:opacity-100">
           {hoverMedia.mediaContentType === 'VIDEO' ? (
             <ProductItemVideo
               autoPlay={false}

--- a/app/components/ProductItem/ProductItemMedia/ProductItemVideo.tsx
+++ b/app/components/ProductItem/ProductItemMedia/ProductItemVideo.tsx
@@ -21,7 +21,7 @@ export const ProductItemVideo = forwardRef(
         loop
         controls={false}
         poster={previewImage?.url}
-        className="absolute inset-0 size-full"
+        className="media-fill"
         key={JSON.stringify(videoSources)}
       >
         {videoSources?.length

--- a/app/data/graphql/pack/blog-page.ts
+++ b/app/data/graphql/pack/blog-page.ts
@@ -1,7 +1,7 @@
 import {SECTION_FRAGMENT} from './settings';
 
 export const BLOG_PAGE_QUERY = `
-  query Blog($first: Int!, $handle: String!, $version: Version, $cursor: String, $articlesCursor: String, $language: String, $country: String) @inContext(language: $language, country: $country) {
+  query Blog($handle: String!, $version: Version, $cursor: String, $articlesCursor: String, $language: String, $country: String) @inContext(language: $language, country: $country) {
     blog: blogByHandle(handle: $handle, version: $version) {
       id
       title

--- a/app/sections/Banner/BannerVideo.tsx
+++ b/app/sections/Banner/BannerVideo.tsx
@@ -18,7 +18,7 @@ export function BannerVideo({
     <div ref={ref} className="absolute inset-0 size-full">
       {(aboveTheFold || inView) && (
         <video
-          className="size-full object-cover"
+          className="media-fill"
           autoPlay
           controls={false}
           loop

--- a/app/sections/BuildYourOwnBundle/BYOBProductItem/BYOBProductItemMedia.tsx
+++ b/app/sections/BuildYourOwnBundle/BYOBProductItem/BYOBProductItemMedia.tsx
@@ -53,7 +53,7 @@ export function BYOBProductItemMedia({
       )}
 
       {hoverMedia && (
-        <div className="hidden opacity-0 transition duration-300 md:block md:group-hover/media:opacity-100">
+        <div className="absolute inset-0 hidden size-full opacity-0 transition duration-300 md:block md:group-hover/media:opacity-100">
           {hoverMedia.mediaContentType === 'VIDEO' ? (
             <BYOBProductItemVideo
               autoPlay={false}
@@ -102,7 +102,7 @@ export const BYOBProductItemVideo = forwardRef(
         loop
         controls={false}
         poster={previewImage?.url}
-        className="absolute inset-0 size-full"
+        className="media-fill"
         key={JSON.stringify(videoSources)}
       >
         {videoSources?.length

--- a/app/sections/HalfHero/HalfHeroVideo.tsx
+++ b/app/sections/HalfHero/HalfHeroVideo.tsx
@@ -33,7 +33,7 @@ export function HalfHeroVideo({
   }, [autoplay, isPlaying, sound]);
 
   return (
-    <div ref={ref} className="absolute inset-0 size-full">
+    <div ref={ref} className="media-fill relative">
       {inView && (
         <video
           autoPlay={autoplay}

--- a/app/sections/Hero/HeroVideo.tsx
+++ b/app/sections/Hero/HeroVideo.tsx
@@ -16,7 +16,7 @@ export function HeroVideo({isVisible, posterUrl, video}: HeroVideoProps) {
 
   return isVisible ? (
     <video
-      className="absolute inset-0 size-full object-cover"
+      className="media-fill"
       controls={false}
       loop
       muted

--- a/app/sections/SocialMediaGrid/SocialMediaGrid.tsx
+++ b/app/sections/SocialMediaGrid/SocialMediaGrid.tsx
@@ -54,7 +54,7 @@ export function SocialMediaGrid({cms}: {cms: SocialMediaGridCms}) {
                         {videoUrl ? (
                           <video
                             autoPlay
-                            className="media-fill object-cover"
+                            className="media-fill"
                             loop
                             muted
                             playsInline
@@ -71,7 +71,6 @@ export function SocialMediaGrid({cms}: {cms: SocialMediaGridCms}) {
                               width: image?.width,
                               height: image?.height,
                             }}
-                            aspectRatio="1/1"
                             className="media-fill"
                             sizes="(min-width: 768px) 25vw, 50vw"
                           />

--- a/app/sections/SocialMediaGrid/SocialMediaGrid.tsx
+++ b/app/sections/SocialMediaGrid/SocialMediaGrid.tsx
@@ -27,7 +27,7 @@ export function SocialMediaGrid({cms}: {cms: SocialMediaGridCms}) {
         className={clsx('py-px', !section?.fullBleed && 'px-contained')}
         ref={ref}
       >
-        <div
+        <ul
           className={clsx(
             'mx-auto grid grid-cols-2 sm:grid-cols-4',
             gridGap,
@@ -89,7 +89,7 @@ export function SocialMediaGrid({cms}: {cms: SocialMediaGridCms}) {
               </li>
             );
           })}
-        </div>
+        </ul>
       </div>
     </Container>
   );

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -466,13 +466,7 @@
     overflow-wrap: anywhere;
   }
   .media-fill {
-    @apply absolute
-      left-1/2
-      top-1/2
-      h-full
-      w-full
-      -translate-x-1/2
-      -translate-y-1/2
+    @apply size-full
       object-cover;
   }
   .absolute-center {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydrogen-starter",
-  "version": "1.13.4",
+  "version": "1.13.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydrogen-starter",
-      "version": "1.13.4",
+      "version": "1.13.5",
       "dependencies": {
         "@fingerprintjs/botd": "^1.9.1",
         "@headlessui/react": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hydrogen-starter",
   "private": true,
   "sideEffects": false,
-  "version": "1.13.4",
+  "version": "1.13.5",
   "type": "module",
   "scripts": {
     "dev": "shopify hydrogen dev --port 8080",


### PR DESCRIPTION
Fix:
- Removes stale Graphql query variable that should have been removed with code cleanup from [release v1.13.3](https://github.com/packdigital/pack-hydrogen-theme-blueprint/releases/tag/v1.13.3) for the blog page query. This would cause the blog route to 404 [[commit](https://github.com/packdigital/pack-hydrogen-theme-blueprint/commit/b5ba05bb278732d78429c89c8279bb0c69895f98)]
- Removes the plugin `plugin:prettier/recommended` in `.eslintrc.cjs` added in [release v1.13.3](https://github.com/packdigital/pack-hydrogen-theme-blueprint/releases/tag/v1.13.3). This was found to conflict with the existing plugin `plugin:hydrogen/recommended` and would break other plugins [[commit](https://github.com/packdigital/pack-hydrogen-theme-blueprint/commit/9449db82ca65add5f63d5fbf3abee18d019994f9)]

Improvement:
- Redefines the utility class `media-fill` in `app.css` to just be `@apply size-full object-cover` [[commit](https://github.com/packdigital/pack-hydrogen-theme-blueprint/commit/ad6b228a7799589dc43933389a4a5daa99c47f35)]
  - Previously this class would center the media via `absolute` and `translate` transform, which had a side effect of the browser sometimes rendering a vertical white pixel line alongside the centered image within the parent container
  - Because this changed elements to change position from `absolute` to `static`, `media-fill` no longer is applicable to some elements and absolute positioning classes are added instead