### PR TITLE
feat: lightweight pre-order support

### DIFF
--- a/app/components/AddToCart.tsx
+++ b/app/components/AddToCart.tsx
@@ -44,7 +44,9 @@ export function AddToCart({
     isAdded,
     isAdding,
     isNotifyMe,
+    isPreorder,
     isSoldOut,
+    preOrderShippingText,
     subtext,
     handleAddToCart,
     handleNotifyMe,
@@ -63,14 +65,23 @@ export function AddToCart({
   }, [isAdded, onAddToCart]);
 
   const isUpdatingClass = isAdding || cartIsUpdating ? 'cursor-default' : '';
-  const isNotifyMeClass = isNotifyMe ? 'btn-inverse-dark' : 'btn-primary';
+  const buttonClass = isPreorder
+    ? 'btn-inverse-dark'
+    : isNotifyMe
+      ? 'btn-inverse-dark'
+      : 'btn-primary';
 
   return (
     <div className={clsx(containerClassName)}>
+      {isPdp && isPreorder && preOrderShippingText && (
+        <p className="mb-3 text-sm">
+          Estimated ship date: {preOrderShippingText}
+        </p>
+      )}
       <button
         aria-label={buttonText}
         className={clsx(
-          isNotifyMeClass,
+          buttonClass,
           'relative w-full',
           isUpdatingClass,
           className,

--- a/app/components/Cart/CartLine/CartLine.tsx
+++ b/app/components/Cart/CartLine/CartLine.tsx
@@ -13,7 +13,11 @@ import {useCartLineImage} from './useCartLineImage';
 import {useCartLinePrices} from './useCartLinePrices';
 
 export const CartLine = memo(({closeCart, line}: CartLineProps) => {
-  const {discountAllocations, merchandise, quantity} = line;
+  const {attributes, discountAllocations, merchandise, quantity} = line;
+
+  const preOrderShippingDate = attributes?.find(
+    (attr) => attr.key === 'Estimated Ship Date',
+  )?.value;
 
   const {handleDecrement, handleIncrement, handleRemove, isUpdatingLine} =
     useCartLine({line});
@@ -65,6 +69,12 @@ export const CartLine = memo(({closeCart, line}: CartLineProps) => {
 
           {merchandise.title !== 'Default Title' && (
             <p className="text-sm text-neutralMedium">{merchandise.title}</p>
+          )}
+
+          {preOrderShippingDate && (
+            <p className="mt-0.5 text-sm text-neutralMedium">
+              Estimated ship date: {preOrderShippingDate}
+            </p>
           )}
 
           <button

--- a/app/components/ProductItem/QuickShop/QuickShopOption.tsx
+++ b/app/components/ProductItem/QuickShop/QuickShopOption.tsx
@@ -22,6 +22,7 @@ export const QuickShopOption = memo(
       cartIsUpdating,
       isAdding,
       isNotifyMe,
+      isPreorder,
       isSoldOut,
       handleAddToCart,
       handleNotifyMe,
@@ -45,6 +46,7 @@ export const QuickShopOption = memo(
         aria-label={optionValue.name}
         className={clsx(
           'group/option relative flex size-full items-center justify-center whitespace-nowrap text-center text-sm transition',
+          isPreorder ? 'border-primary bg-primary/10' : '',
           validClass,
           unavailableClass,
           isUpdatingClass,

--- a/app/data/graphql/storefront/product.ts
+++ b/app/data/graphql/storefront/product.ts
@@ -39,6 +39,7 @@ export const VARIANT_FRAGMENT = `#graphql
     id
     title
     availableForSale
+    currentlyNotInStock
     sku
     weight
     weightUnit

--- a/app/hooks/product/useAddToCart.ts
+++ b/app/hooks/product/useAddToCart.ts
@@ -43,7 +43,9 @@ interface UseAddToCartReturn {
   isAdded: boolean;
   isAdding: boolean;
   isNotifyMe: boolean;
+  isPreorder: boolean;
   isSoldOut: boolean;
+  preOrderShippingText: string;
   subtext: string;
 }
 
@@ -67,6 +69,12 @@ export function useAddToCart({
   const variantIsSoldOut = selectedVariant && !selectedVariant.availableForSale;
   const variantIsPreorder = !!selectedVariant?.currentlyNotInStock;
 
+  const preOrderOverride = variantIsPreorder
+    ? productSettings?.preOrderOverrides?.find(
+        (o) => o.product?.handle === selectedVariant?.product?.handle,
+      )
+    : undefined;
+
   let buttonText = '';
   if (failed) {
     buttonText = productSettings?.addToCart?.failedText || 'Failed To Add';
@@ -89,9 +97,18 @@ export function useAddToCart({
     if (!selectedVariant?.id || isAdding || cartIsUpdating) return;
     setIsAdding(true);
     setFailed(false);
+
+    const lineAttributes = [...(attributes || [])];
+    if (variantIsPreorder && preOrderOverride?.shippingDateText) {
+      lineAttributes.push({
+        key: 'Estimated Ship Date',
+        value: preOrderOverride.shippingDateText,
+      });
+    }
+
     const data = await linesAdd([
       {
-        attributes,
+        attributes: lineAttributes,
         merchandiseId: selectedVariant.id,
         quantity,
         sellingPlanId,
@@ -113,10 +130,12 @@ export function useAddToCart({
     attributes,
     isAdding,
     linesAdd,
+    preOrderOverride?.shippingDateText,
     quantity,
     selectedVariant?.id,
     sellingPlanId,
     status,
+    variantIsPreorder,
   ]);
 
   const handleNotifyMe = useCallback(
@@ -157,7 +176,9 @@ export function useAddToCart({
     isAdded, // line is added (true for only a second)
     isAdding, // line is adding
     isNotifyMe: !!variantIsSoldOut && enabledNotifyMe,
+    isPreorder: variantIsPreorder,
     isSoldOut: !!variantIsSoldOut,
+    preOrderShippingText: preOrderOverride?.shippingDateText || '',
     subtext: productSettings?.addToCart?.subtext,
   };
 }

--- a/app/settings/product.ts
+++ b/app/settings/product.ts
@@ -1,4 +1,4 @@
-import type {Swatch} from '~/lib/types';
+import type {ProductCms, Swatch} from '~/lib/types';
 
 import {COLOR_PICKER_DEFAULTS, COLOR_SCHEMA_DEFAULT_VALUE} from './common';
 
@@ -10,6 +10,10 @@ export interface ProductSettings {
     failedText: string;
     subtext: string;
   };
+  preOrderOverrides: {
+    product: ProductCms;
+    shippingDateText: string;
+  }[];
   backInStock: {
     enabled: boolean;
     notifyMeText: string;
@@ -91,6 +95,35 @@ export default {
         failedText: 'Failed To Add',
         subtext: '',
       },
+    },
+    {
+      label: 'Pre-Order Overrides',
+      name: 'preOrderOverrides',
+      component: 'group-list',
+      description:
+        'Per-product pre-order shipping date configuration. Enable "Continue selling when out of stock" in Shopify admin for each product.',
+      itemProps: {
+        label: '{{item.product.handle}}',
+      },
+      defaultItem: {
+        shippingDateText: 'TBD',
+      },
+      fields: [
+        {
+          label: 'Product',
+          name: 'product',
+          component: 'productSearch',
+        },
+        {
+          label: 'Shipping Date Text',
+          name: 'shippingDateText',
+          component: 'text',
+          description:
+            'Enter the date only (e.g. "April 15, 2026"). Displayed as "Estimated ship date: [value]" on PDP, cart, and checkout.',
+          defaultValue: 'TBD',
+        },
+      ],
+      defaultValue: [],
     },
     {
       label: 'Back In Stock',


### PR DESCRIPTION
## Summary

Adds lightweight, out-of-the-box pre-order support that works entirely within Shopify's native inventory system — no custom apps, metafields, or backend changes required.

### How it works

Enable **"Continue selling when out of stock"** on a product variant in Shopify admin and configure a shipping date in Pack Customizer. The storefront detects the `currentlyNotInStock` state (inventory = 0, `inventoryPolicy: CONTINUE`) and:

- Switches the ATC button text to "Preorder" (configurable in Customizer)
- Applies a distinct button style to signal the pre-order state to customers
- Displays an estimated ship date message below the button on PDP
- Surfaces the shipping date at checkout and in order confirmation emails as a visible line item property — no Shopify theme changes changes needed
- Shows the shipping date on the cart line item
- Highlights pre-order options in Quick Shop

### Changes

| File | Change |
|------|--------|
| `app/data/graphql/storefront/product.ts` | Add `currentlyNotInStock` to `VARIANT_FRAGMENT` — the missing piece that activates detection (field was referenced in the hook but never fetched) |
| `app/hooks/product/useAddToCart.ts` | Expose `isPreorder` + `preOrderShippingText`; push `"Estimated Ship Date"` line item property (no `_` prefix = visible at checkout) |
| `app/components/AddToCart.tsx` | Pre-order button style + estimated ship date message on PDP |
| `app/components/Cart/CartLine/CartLine.tsx` | Read shipping date from line attributes — accurate per-variant, no extra settings lookup |
| `app/components/ProductItem/QuickShop/QuickShopOption.tsx` | Visual highlight for pre-order options |
| `app/settings/product.ts` | Add `preOrderOverrides` group-list CMS schema for per-product shipping date configuration |

### Setup (for implementors)

1. In Shopify admin → Product → Inventory: enable **"Continue selling when out of stock"** and set inventory to the pre-order limit
2. In Pack Customizer → Site Settings → Product → Pre-Order Overrides: add the product and set the shipping date text (e.g. `"April 15, 2026"`)
3. The storefront handles the rest automatically

### Design note

The pre-order button uses `btn-inverse-dark` by default — implementors should swap this for their brand's pre-order style (e.g. a teal/accent color). The `isPreorder` boolean is exposed from `useAddToCart` for any additional customization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)