### PR TITLE
fix(analytics): correct search list field and guard empty results in Fueled events

### DIFF
--- a/app/components/Analytics/FueledEvents/events.ts
+++ b/app/components/Analytics/FueledEvents/events.ts
@@ -274,7 +274,7 @@ const viewSearchResultsEvent = ({
     if (debug) logSubscription({data, analyticsEvent});
 
     const {searchResults, searchTerm, customer, shop} = data;
-    if (!searchResults || !searchTerm)
+    if (!searchResults || !searchTerm || !searchResults.length)
       throw new Error(
         '`searchTerm` and/or `searchResults` parameters are missing.',
       );
@@ -290,7 +290,7 @@ const viewSearchResultsEvent = ({
           list: 'search results',
           search_term: searchTerm,
         },
-        products: searchResults.slice(0, 12).map(mapProductItemProduct()),
+        products: searchResults.slice(0, 12).map(mapProductItemProduct('search results')),
       },
     };
     dispatchEvent({event, debug});
@@ -486,7 +486,7 @@ const clickProductItemEvent = ({
             action: 'click',
             ...(!!searchTerm && {search_term: searchTerm}),
           },
-          products: [variant].map(mapProductItemVariant(list)),
+          products: [variant].map(mapProductItemVariant(searchTerm ? 'search results' : list)),
         },
       },
     };


### PR DESCRIPTION
## Summary

Three bugs in `FueledEvents/events.ts` affecting search tracking:

- **`dl_view_search_results` per-product `list` was `""`** — `mapProductItemProduct()` was called without an argument, so every product in the results had `list: ""` instead of `"search results"`. Fixed by passing `mapProductItemProduct('search results')`.
- **`dl_select_item` per-product `list` was `""` from `/search`** — `actionField.list` correctly resolved to `"search results"` when `searchTerm` was truthy, but the product mapper received the raw `list` variable (`""` on `/search`). Fixed by using `mapProductItemVariant(searchTerm ? 'search results' : list)`.
- **Spurious `dl_view_search_results` with empty `products: []`** — `SearchSuggestions` mounts `<Analytics.SearchView data={{searchTerm, searchResults: []}} />` as soon as the user starts typing (before results load). The existing guard checked `!searchResults` but an empty array is truthy, so the event fired with no products. Fixed by adding `!searchResults.length` to the guard.

## Test plan

- [ ] Navigate to `/search?q=<term>` — confirm `dl_view_search_results` fires once with `products[n].list === "search results"`
- [ ] Type in search drawer — confirm `dl_view_search_results` does NOT fire before results load
- [ ] Click a search result product card — confirm `dl_select_item` fires with `click.products[0].list === "search results"` and `click.actionField.search_term` present
- [ ] Click a collection product card — confirm `dl_select_item` still uses collection path as `list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)