### PR TITLE
Add Claude Code configuration for storefront development

### DIFF
--- a/.claude/agents/requirements.md
+++ b/.claude/agents/requirements.md
@@ -1,0 +1,67 @@
+---
+name: requirements
+description: Plan features and changes by drafting a structured spec before implementation. Use when a new feature is proposed, a non-trivial refactor is needed, a bug fix crosses multiple concerns, or someone asks "what would it take to..." without a spec.
+tools: Read, Glob, Grep
+model: sonnet
+---
+
+You are the Requirements & Solution Architect for this repository. You reduce development churn by forcing clarity before code changes.
+
+## Workflow
+
+Guide the user through these steps in order. Do NOT skip steps — each phase builds on the previous one.
+
+### 1. Problem Clarification
+Ask questions until the problem is well-defined:
+- What is broken, missing, or suboptimal?
+- Who is affected (end users, merchants, developers)?
+- What does success look like?
+
+### 2. Codebase Discovery
+Search the repo for related code:
+- Identify relevant files and call paths
+- Summarize current behavior with specific file references (`app/path/to/file.tsx:lineNumber`)
+- Confirm understanding with the user before proceeding
+
+### 3. Requirements Drafting
+Write a clear spec with:
+- **Goal** — concrete, measurable outcome
+- **Non-goals** — what is explicitly out of scope
+- **User stories** — who benefits and how
+- **Technical approach** — what components, routes, or modules change
+
+### 4. Acceptance Criteria
+Define testable pass/fail conditions for the change. Each criterion must be independently verifiable.
+
+### 5. Risk Analysis
+Identify:
+- Edge cases (empty states, error states, concurrent access)
+- Performance concerns (bundle size, API load)
+- Breaking changes (existing behavior other code depends on)
+- Edge runtime limitations (no Node.js APIs on Oxygen)
+
+### 6. Implementation Planning
+- List every impacted file (create, modify, delete)
+- Outline rollout strategy
+- Surface open questions that must be answered before coding
+
+## Output
+
+Save the spec to `docs/specs/<feature-name>.md`. If `docs/specs/_template.md` exists, use it. Otherwise, follow the structure above directly — do NOT create a template file.
+
+## Constraints
+
+- Do NOT write production code unless explicitly asked
+- Do NOT approve a spec with unresolved open questions without explicit acknowledgment
+- Do NOT assume requirements — ask when something is ambiguous
+- Respect the conventions in `CLAUDE.md` (route naming, import ordering, edge runtime limitations, Pack CMS patterns)
+
+## Pushback Criteria
+
+Push back and ask for clarification when:
+- Requirements are vague ("make it better" without measurable goals)
+- Acceptance criteria are missing
+- The change duplicates existing functionality
+- Architectural risk is present (shared infrastructure, sessions, build pipeline)
+- Edge cases are ignored
+- Referenced file paths don't exist in the repo

--- a/.claude/commands/add-integration.md
+++ b/.claude/commands/add-integration.md
@@ -1,0 +1,41 @@
+---
+description: Wire up a new third-party integration (API route, lib module, env vars)
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+---
+
+Add a new third-party integration for $ARGUMENTS to this storefront.
+
+## Steps
+
+1. **Research the integration**: Determine what the integration needs:
+   - Client-side script (tracking pixel, widget)?
+   - Server-side API calls (subscriptions, webhooks)?
+   - Both?
+
+2. **Check for existing work**: Search `app/lib/`, `app/components/Analytics/`, and `app/routes/` for any existing implementation of this integration.
+
+3. **Create the lib module** (if server-side API calls needed):
+   - Create `app/lib/{integration-name}/` directory
+   - Add types, API client functions, and utilities
+   - Follow patterns from existing integrations (e.g., check `app/lib/klaviyo/` for reference)
+
+4. **Create the API route** (if server-side):
+   - Create `app/routes/($locale).api.{integration-name}.tsx`
+   - Export `loader` and/or `action` functions
+   - Follow the pattern of existing API routes
+
+5. **Add client-side scripts** (if needed):
+   - Add to `app/components/Analytics/` for analytics/tracking scripts
+   - Or create a dedicated component in `app/components/`
+   - Use `useLoadScript()` hook for dynamic script loading
+
+6. **Document environment variables**:
+   - List any new env vars needed (with `PUBLIC_` or `PRIVATE_` prefix as appropriate)
+   - Update the integrations rule in `.claude/rules/integrations.md`
+   - Note: Oxygen secrets must be configured separately via Shopify Admin
+
+7. **Verify**:
+   - Run `npm run typecheck`
+   - Run `npm run lint`
+
+Report the created/modified files and any environment variables that need to be configured.

--- a/.claude/commands/new-section.md
+++ b/.claude/commands/new-section.md
@@ -1,0 +1,35 @@
+---
+description: Scaffold a new Pack CMS section with component, schema, and registration
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+---
+
+Create a new Pack CMS section named $ARGUMENTS in this repo.
+
+## Steps
+
+1. **Check for conflicts**: Search `app/sections/` for an existing section with this name. If found, report it and stop.
+
+2. **Find a reference section**: Read 2-3 existing sections in `app/sections/` to match the project's patterns (imports, typing, component structure). Prefer simpler sections like `TextBlock` or `Banner` as templates.
+
+3. **Create the section directory and component**:
+   - Create `app/sections/{SectionName}/{SectionName}.tsx`
+   - Export a default functional component accepting `{cms}` prop
+   - Use the `<Section>` wrapper component
+   - Include proper TypeScript types for the CMS data shape
+   - Follow the import ordering enforced by ESLint (builtin > external > internal > parent > sibling)
+
+4. **Create the section schema** (co-located with the component):
+   - Create `app/sections/{SectionName}/{SectionName}.schema.ts`
+   - Export a `Schema` function returning `{ category, label, key, previewSrc, fields }`
+   - In the component file, attach it: `{SectionName}.Schema = Schema`
+   - Match field types to Pack's supported schema types (check existing `.schema.ts` files for examples)
+
+5. **Register the section**:
+   - Edit `app/sections/index.tsx` to import and call `registerSection()`
+   - Follow alphabetical ordering of existing registrations
+
+6. **Verify**:
+   - Run `npm run typecheck` to confirm no type errors
+   - Run `npm run lint` to confirm no lint violations
+
+Report the created files and their locations when done.

--- a/.claude/commands/preflight.md
+++ b/.claude/commands/preflight.md
@@ -1,0 +1,36 @@
+---
+description: Run lint, typecheck, and build to verify changes before pushing
+allowed-tools: Bash
+---
+
+Run all quality checks to verify the codebase is clean before pushing.
+
+## Steps
+
+Run these checks sequentially, stopping on the first failure:
+
+1. **Lint**: `npm run lint`
+   - If violations found, report them with file paths and line numbers
+   - Suggest fixes but do not auto-fix
+
+2. **TypeScript**: `npm run typecheck`
+   - If type errors found, report them with file paths and line numbers
+
+3. **Build**: `npm run build`
+   - If build fails, report the error
+
+## Output
+
+Report results as:
+
+```
+Preflight Results
+-----------------
+Lint:      PASS | FAIL (N issues)
+Typecheck: PASS | FAIL (N errors)
+Build:     PASS | FAIL
+
+{Details of any failures}
+```
+
+If all pass, confirm the codebase is ready to push.

--- a/.claude/commands/refresh-rules.md
+++ b/.claude/commands/refresh-rules.md
@@ -1,0 +1,31 @@
+---
+description: Re-discover the codebase and regenerate .claude/rules/ files
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+---
+
+Re-scan the codebase and update all `.claude/rules/` files to reflect current state.
+
+## Steps
+
+Run all discovery in parallel:
+
+1. **Sections**: Read `app/sections/index.tsx` for all `registerSection()` calls. Update the "Registered Sections" list in `.claude/rules/sections.md`.
+
+2. **Integrations**: Scan `app/lib/` directories, `app/components/Analytics/`, and `app/routes/` for API routes. Update the integrations and analytics tables in `.claude/rules/integrations.md`.
+
+3. **Settings**: Read `app/settings/index.ts` for registered settings. Update the "Active Settings Files" table in `.claude/rules/schemas.md`.
+
+4. **Styling**: Read `app/styles/app.css`, `app/styles/fonts.css`, and `tailwind.config.js`. Update colors, fonts, breakpoints, layout constants, and component classes in `.claude/rules/styling.md`.
+
+5. **Routes**: Check `app/routes/` for new API routes. Grep for `context.admin` to confirm availability. Update `.claude/rules/routes.md`.
+
+## Output
+
+Report what changed:
+- Sections added/removed
+- New integrations or env vars detected
+- Settings files added/removed
+- Styling token changes
+- Route changes
+
+Only overwrite rules that actually changed. Leave unchanged rules alone.

--- a/.claude/rules/integrations.md
+++ b/.claude/rules/integrations.md
@@ -1,0 +1,44 @@
+---
+paths:
+  - "app/lib/klaviyo/**"
+  - "app/lib/admin-api/**"
+  - "app/lib/customer/**"
+  - "app/components/Analytics/**"
+  - "app/routes/($locale).api.klaviyo.tsx"
+---
+
+# Third-Party Integration Conventions
+
+## Active Integrations
+
+| Integration | Directory | API Route | Key Env Vars |
+|---|---|---|---|
+| Klaviyo | `app/lib/klaviyo/` | `($locale).api.klaviyo.tsx` | `PUBLIC_KLAVIYO_API_KEY`, `PRIVATE_KLAVIYO_API_KEY`, `PUBLIC_KLAIVYO_REVISION` |
+| Admin API | `app/lib/admin-api/` | None (used in loaders) | `PRIVATE_ADMIN_API_TOKEN` |
+| Customer | `app/lib/customer/` | None (used in account routes) | `PUBLIC_CUSTOMER_ACCOUNT_API_CLIENT_ID` |
+
+> **Known typo:** `PUBLIC_KLAIVYO_REVISION` — the env var is misspelled ("KLAIVYO" instead of "KLAVIYO"). Defaults to `2024-05-15`.
+
+## Analytics (app/components/Analytics/)
+
+Analytics integrations are conditionally loaded based on env vars:
+
+| Platform | Env Var | Status |
+|---|---|---|
+| Blotout | `PUBLIC_BLOTOUT_EDGE_URL` | Conditional |
+| Elevar | `PUBLIC_ELEVAR_SIGNING_KEY` | Conditional |
+| GA4 | `PUBLIC_GA4_TAG_ID` | Conditional |
+| Klaviyo | `PUBLIC_KLAVIYO_API_KEY` | Conditional |
+| Meta Pixel | `PUBLIC_META_PIXEL_ID` | Conditional |
+| TikTok Pixel | `PUBLIC_TIKTOK_PIXEL_ID` | Conditional |
+| Fueled | Hardcoded | Disabled by default |
+
+Fueled events (`app/components/Analytics/FueledEvents/`) are disabled by default (`enabledFueled = false` in Analytics.tsx). Enable when wiring up client-specific tracking.
+
+## Conventions
+
+- Each integration lives in its own `app/lib/{name}/` directory
+- Server-side API calls go through a corresponding `api.{name}.tsx` route
+- Client-side scripts load through `app/components/Analytics/` or via `useLoadScript()` hook
+- Environment variables follow the pattern: `PRIVATE_` prefix for server-only, `PUBLIC_` for client-exposed
+- Never expose private API keys to the client bundle — keep them in loaders/actions only

--- a/.claude/rules/routes.md
+++ b/.claude/rules/routes.md
@@ -1,0 +1,41 @@
+---
+paths:
+  - "app/routes/**"
+---
+
+# Route Conventions
+
+- File-based routing via React Router 7 (`@react-router/fs-routes`)
+- All customer-facing routes use `($locale)` optional prefix for i18n
+- Route modules can export: `loader`, `action`, `meta`, `links`, `headers`, `shouldRevalidate`
+- The `react-refresh/only-export-components` ESLint rule is active — route files are exempt for the exports listed above, but other non-component exports will error
+
+## Data Fetching
+
+Three data sources available in loaders via `context`:
+
+| Source | Client | Usage |
+|---|---|---|
+| `context.storefront` | Shopify Storefront API | Products, collections, cart, search |
+| `context.pack` | Pack CMS | Page content, site settings |
+| `context.admin` | Shopify Admin API | Draft/preview products, metafields (optional — only available if `PRIVATE_ADMIN_API_TOKEN` is set) |
+
+Additional context: `session`, `env`, `oxygen`, `cache`, `waitUntil`, `cart`
+
+## Caching
+
+- `CacheShort()` — dynamic content (products, search results)
+- `CacheLong()` — stable content (pages, collection metadata)
+- Cache is backed by Oxygen worker cache (`caches.open('hydrogen')`)
+
+## API Routes
+
+API routes (`api.*.tsx`) are server-only JSON endpoints — no React component export. Return `Response` or `json()`.
+
+Current API routes: articles, cart, collection, countries, klaviyo, predictive-search, product-by-id, product, products, recommendations, redirect, reviews, search
+
+## Common Pitfalls
+
+- Missing `($locale)` prefix breaks locale routing
+- `shouldRevalidate` in root.tsx prevents unnecessary refetches — root data may be stale during SPA navigations
+- `context.admin` is conditionally available — always check before using. It requires `PRIVATE_ADMIN_API_TOKEN` env var to be set.

--- a/.claude/rules/schemas.md
+++ b/.claude/rules/schemas.md
@@ -1,0 +1,43 @@
+---
+paths:
+  - "app/settings/**"
+---
+
+# Pack Storefront Settings Conventions
+
+This rule covers **global storefront settings** in `app/settings/`. Section-specific schemas (`.schema.ts` files co-located with section components in `app/sections/`) are covered by the sections rule.
+
+## Structure
+
+Each settings file exports a schema object with:
+- `label` — display name in Pack editor
+- `fields` — array of field definitions (text, image, color, select, etc.)
+- `defaultValue` — initial values for new instances
+
+## Settings Registry
+
+All settings are registered in `app/settings/index.ts` via `registerStorefrontSettingsSchema()`.
+
+## Active Settings Files
+
+| File | Controls |
+|---|---|
+| `account/` | Account management (login, register, activate, forgot/reset password, orders, menu) |
+| `analytics.ts` | Shopify analytics toggle |
+| `cart.ts` | Cart configuration (discounts, free shipping, upsells) |
+| `collection.ts` | Collection page settings (promo tiles, filters, sorting) |
+| `footer.ts` | Footer styling (colors, marketing signup, legal links) |
+| `header.ts` | Header configuration (promobar, navigation, search) |
+| `localization.ts` | Shopify localization / country selector toggle |
+| `not-found.ts` | 404 page customization (banner CMS type) |
+| `product.ts` | Product page settings (add-to-cart, back-in-stock, reviews) |
+| `search.ts` | Search configuration (autocomplete, suggestions) |
+
+Shared utilities: `common.ts` (reusable field definitions), `container.ts` (container/layout schema)
+
+## Conventions
+
+- Schema field types must match Pack's supported types — check existing settings for examples
+- Default values should reflect the current live site design
+- Settings file names use kebab-case, matching the setting key in Pack
+- Section settings (for individual sections) live alongside the section component, not in this directory

--- a/.claude/rules/sections.md
+++ b/.claude/rules/sections.md
@@ -1,0 +1,35 @@
+---
+paths:
+  - "app/sections/**"
+---
+
+# Section Conventions
+
+- Every section must be registered in `app/sections/index.tsx` via `registerSection()` from `@pack/react`
+- Each section has a co-located schema file (`{SectionName}.schema.ts`) that exports a `Schema` function returning the schema object. The component attaches it: `Component.Schema = Schema`
+- Sections receive CMS data via the `cms` prop — never hardcode page content
+- Co-locate sub-components in the section's directory (e.g., `app/sections/Hero/HeroSlide.tsx`)
+- Sections are rendered via `<RenderSections />` from `@pack/react` — they are never imported directly in routes
+- Use the `<Section>` wrapper component for consistent container/spacing behavior
+- Check existing sections before creating new ones — many content needs are covered by existing types
+
+## Registered Sections
+
+**Text:** rich-text, text-block, markdown, accordions, icon-row, marquee
+**Hero:** hero, half-hero, banner
+**Featured Media:** image-tiles, image-tiles-grid, image-tiles-mosaic, tabbed-tiles-slider, tiles-slider, tiles-stack, social-media-grid
+**Media:** image, video, video-embed
+**Product:** product, products-slider, product-recommendations-slider, shoppable-social-video, shoppable-products-grid, build-your-own-bundle
+**Reviews:** press-slider, testimonial-slider, product-reviews
+**Form:** form-builder, marketing-signup
+**HTML:** html
+**Blog:** blog-categories, blog-grid
+**Metaobject:** metaobject-text-block, metaobject-image
+
+## Creating a New Section
+
+1. Create directory: `app/sections/{SectionName}/`
+2. Create component: `{SectionName}.tsx` — export default functional component accepting `{cms}` prop
+3. Create schema: `app/sections/{SectionName}/{SectionName}.schema.ts` — export a `Schema` function returning `{ category, label, key, previewSrc, fields }`
+4. Register in `app/sections/index.tsx`: import and call `registerSection()`
+5. Run `npm run typecheck` to verify types

--- a/.claude/rules/styling.md
+++ b/.claude/rules/styling.md
@@ -1,0 +1,88 @@
+---
+paths:
+  - "app/styles/**"
+  - "tailwind.config.js"
+  - "postcss.config.cjs"
+---
+
+# Styling Conventions
+
+## Tailwind CSS
+
+- All styling uses Tailwind utility classes — avoid inline styles and custom CSS where possible
+- Custom design tokens are CSS custom properties in `app/styles/app.css`, referenced in `tailwind.config.js`
+- Semantic component classes are defined in the `@layer components` block of `app.css`
+- Plugin: `@headlessui/tailwindcss` for accessible component state styling
+
+## Breakpoints
+
+| Token | Size |
+|---|---|
+| `xs` | 480px (30rem) |
+| `sm` | 640px (40rem) |
+| `md` | 768px (48rem) |
+| `lg` | 1024px (64rem) |
+| `xl` | 1280px (80rem) |
+| `2xl` | 1536px (96rem) |
+
+## Color System
+
+CSS custom properties (defined in `app/styles/app.css`):
+
+| Token | Default |
+|---|---|
+| `--primary` | #008464 |
+| `--secondary` | #8164bf |
+| `--accent1` | #189cc5 |
+| `--accent2` | #4a69d4 |
+| `--black` | #000000 |
+| `--white` | #ffffff |
+| `--text` | #000000 |
+| `--background` | #ffffff |
+| `--border` | #e8e8e8 |
+| `--overlay` | rgba(0, 0, 0, 0.3) |
+| Neutral scale | `--neutral-darkest` through `--neutral-lightest` |
+
+Button color variables: `--primary-btn-*`, `--secondary-btn-*`, `--inverse-light-btn-*`, `--inverse-dark-btn-*` (each with `bg-color`, `border-color`, `text-color` + hover variants)
+
+## Fonts
+
+| Font | Role | Source |
+|---|---|---|
+| Poppins | `sans` (body) + `heading` | System/CDN |
+
+Font faces can be declared in `app/styles/fonts.css` (currently empty — Poppins loaded via default).
+
+## Layout Constants
+
+| Token | Value |
+|---|---|
+| `--header-height-mobile` | 4.5rem |
+| `--header-height-desktop` | 4.5rem |
+| `--promobar-height-mobile` | 3rem |
+| `--promobar-height-desktop` | 3rem |
+| `--drawer-width` | 23.5rem |
+| `--content-max-width` | 96rem |
+| `--product-image-aspect-ratio` | 3 / 4 |
+
+## Font Sizes
+
+2xs (10px), xs (12px), sm (14px), base (16px), lg (18px), xl (20px), 2xl (24px), 3xl (30px), 4xl (36px), 5xl (48px), 6xl (60px), 7xl (72px), 8xl (96px), 9xl (128px)
+
+## Component Classes
+
+**Typography:** `.text-h1` through `.text-h6`, `.text-body`, `.text-body-sm`, `.text-body-lg`, `.text-link`, `.text-caption`, `.text-label`, `.text-nav`, `.text-superheading`
+**Buttons:** `.btn`, `.btn-primary`, `.btn-secondary`, `.btn-inverse-light`, `.btn-inverse-dark`, `.btn-select`
+**Inputs:** `.input-text`, `.input-label`
+**Layout:** `.px-contained`, `.py-contained`, `.pt-contained`, `.pb-contained`, `.media-fill`, `.absolute-center`, `.scrollbar-hide`, `.overflow-anywhere`
+
+## Animations
+
+- `spin-fast` (0.75s), `bounce-high` (0.75s), `flash` (1.5s), `shimmer` (horizontal translate)
+
+## Conventions
+
+- Use `px-contained` / `py-contained` utility classes for consistent page padding
+- Button styles use CSS custom properties for theming — modify `--*-btn-*` vars, not Tailwind classes
+- Swiper carousel styles have custom overrides in `app.css` — check before modifying slider CSS
+- `assetsInlineLimit: 0` in Vite config — no base64 inlining (CSP compliance)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,63 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run dev*)",
+      "Bash(npm run build*)",
+      "Bash(npm run lint*)",
+      "Bash(npm run format*)",
+      "Bash(npm run typecheck*)",
+      "Bash(npm run codegen*)",
+      "Bash(npx shopify hydrogen*)",
+      "Bash(npx eslint *)",
+      "Bash(npx prettier *)",
+      "Bash(npx tsc *)",
+      "Bash(npm install *)",
+      "Bash(npm ls *)",
+      "Bash(npm outdated *)",
+      "Bash(git status*)",
+      "Bash(git log*)",
+      "Bash(git diff*)",
+      "Bash(git branch*)",
+      "Bash(git checkout*)",
+      "Bash(git stash*)",
+      "Bash(git show*)",
+      "Bash(ls *)"
+    ],
+    "deny": [
+      "Bash(rm -rf *)",
+      "Bash(git push*)",
+      "Bash(git reset --hard*)",
+      "Bash(npx wrangler*)",
+      "Bash(npm publish*)",
+      "Edit(.env*)",
+      "Write(.env*)",
+      "Read(.env*)",
+      "Edit(.vercel/**)",
+      "Write(.vercel/**)",
+      "Read(.vercel/**)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file=\"$CLAUDE_FILE_PATH\"; if [[ \"$file\" == *.ts || \"$file\" == *.tsx || \"$file\" == *.js || \"$file\" == *.jsx ]]; then npx eslint --fix \"$file\" 2>&1 || true; fi; exit 0"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx tsc --noEmit --pretty 2>&1 | head -100; exit 0"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ node_modules
 
 # IntelliJ
 .idea
+
+# Claude Code personal settings (not shared)
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# Pack Hydrogen Theme Blueprint
+
+Starter template for Shopify Hydrogen storefronts built on Pack CMS. This is the base repo that all client storefronts are forked from.
+
+## Tech Stack
+
+- Hydrogen 2026.1.0 / React Router 7.12 / React 18.3
+- Pack SDKs: @pack/hydrogen ^3.1.0, @pack/react ^4.0.0, @pack/client ^1.0.3
+- Tailwind CSS 3.4 + PostCSS
+- TypeScript 5.9 (strict mode)
+- Vite 6.2 build tooling
+- Deploys to Shopify Oxygen (edge runtime)
+
+## Key Directories
+
+| Directory | Purpose |
+|-----------|---------|
+| `app/sections/` | 33 CMS sections registered via `registerSection()` |
+| `app/settings/` | 10 global storefront settings schemas |
+| `app/routes/` | File-based routing with `($locale)` prefix, 13 API routes |
+| `app/lib/` | Server utilities (Klaviyo, admin-api, customer, session) |
+| `app/hooks/` | 20+ React hooks |
+| `app/components/` | UI components (Document, Layout, Cart, Analytics, etc.) |
+| `app/styles/` | Global CSS, fonts, design tokens |
+| `app/contexts/` | React context providers |
+
+## Pack Documentation
+
+- https://docs.packdigital.com
+- https://docs.packdigital.com/llms-full.txt
+
+## Claude Code
+
+This repo ships with pre-configured Claude Code tooling:
+
+| Path | Purpose |
+|------|---------|
+| `.claude/settings.json` | Permissions, auto-lint hook, typecheck on stop |
+| `.claude/rules/` | Conditional rules for sections, routes, integrations, schemas, styling |
+| `.claude/commands/` | `/new-section`, `/add-integration`, `/preflight`, `/refresh-rules` |
+| `.claude/agents/` | `/requirements` planning subagent |
+
+After customizing the storefront (adding sections, integrations, etc.), run `/refresh-rules` to update the rules files.
+
+## Conventions
+
+- All sections use `registerSection()` from `@pack/react`
+- Section schemas co-located as `{SectionName}.schema.ts`
+- Routes use `($locale)` prefix for i18n
+- Data fetching via `context.storefront` (Shopify) and `context.pack` (CMS)
+- `context.admin` conditionally available (requires `PRIVATE_ADMIN_API_TOKEN`)
+- Tailwind utilities preferred; CSS custom properties for design tokens
+- ESLint (`@shopify/hydrogen` plugin) + Prettier (`@shopify/prettier-config`) enforced
+- `PRIVATE_` prefix for server-only env vars, `PUBLIC_` for client-exposed


### PR DESCRIPTION
## Summary

- Ships a `.claude/` directory in the blueprint so anyone who clones or forks it gets pre-configured Claude Code tooling
- Adds conditional rules (sections, routes, integrations, schemas, styling) that only load when editing relevant files
- Adds slash commands: `/new-section`, `/add-integration`, `/preflight`, `/refresh-rules`
- Adds a `/requirements` planning agent for spec-first development
- Auto-lint hook on file edits, typecheck on session stop
- `CLAUDE.md` at root for project context
- `settings.local.json` excluded via `.gitignore` so personal overrides stay private

## What's included

| Path | Purpose |
|------|---------|
| `.claude/settings.json` | Permissions, hooks (auto-lint, typecheck) |
| `.claude/rules/sections.md` | 33 registered sections, conventions |
| `.claude/rules/routes.md` | Route patterns, data fetching context |
| `.claude/rules/integrations.md` | Klaviyo, Admin API, analytics platforms |
| `.claude/rules/schemas.md` | 10 settings files inventory |
| `.claude/rules/styling.md` | Design tokens, fonts, colors, breakpoints |
| `.claude/commands/` | new-section, add-integration, preflight, refresh-rules |
| `.claude/agents/requirements.md` | Requirements & Solution Architect |
| `CLAUDE.md` | Project context for AI assistants |

## Test plan

- [ ] Clone the repo fresh and verify `.claude/` structure is present
- [ ] Open in Claude Code and confirm rules load conditionally (edit a section file → sections rule loads)
- [ ] Run `/preflight` to verify the command works
- [ ] Verify `settings.local.json` is not tracked (`git status` shows it untracked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)