### PR TITLE
Fix draft PDP preview in Customizer

### DIFF
--- a/app/routes/($locale).products.$handle.tsx
+++ b/app/routes/($locale).products.$handle.tsx
@@ -108,7 +108,7 @@ export async function loader({params, context, request}: Route.LoaderArgs) {
 
   const product = await getProductWithInitialGrouping({
     context,
-    product: storefrontProduct,
+    product: queriedProduct,
     productGroupings,
   });
 


### PR DESCRIPTION
## Summary
- The PDP loader falls back to Admin API for draft products when Pack preview mode is enabled, populating `queriedProduct` from `normalizeAdminProduct(adminProduct)`.
- However, the next call to `getProductWithInitialGrouping` was passing the original `storefrontProduct` (still `null` for draft products) instead of `queriedProduct`, causing a TypeError when downstream code accessed `product.handle` / spread `...product`.
- Result: draft PDPs 500 in the Customizer even when `PRIVATE_ADMIN_API_TOKEN` is configured and the admin client returns the draft product successfully.
- Fix matches the pattern already used in `getModalProduct` (`app/lib/server-utils/product.server.ts:318`), which correctly uses `queriedProduct` after the admin fallback.

## Test plan
- [ ] With `PRIVATE_ADMIN_API_TOKEN` set on the Hydrogen storefront, open a Shopify product in **Draft** status via the Pack Customizer PDP route.
- [ ] Confirm the page renders (previously would error out).
- [ ] Confirm published/active products continue to render normally (fix is a no-op when `storefrontProduct === queriedProduct`).
- [ ] Confirm live traffic to a draft PDP still 404s (fallback is gated on `isPreviewModeEnabled`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)