### PR TITLE
fix(analytics): label the two search surfaces so they stop double-counting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ node_modules
 .shopify
 .hydrogen
 .react-router
+tsconfig.tsbuildinfo
 
 # IntelliJ
 .idea

--- a/app/components/Analytics/ElevarEvents/events.ts
+++ b/app/components/Analytics/ElevarEvents/events.ts
@@ -1,6 +1,6 @@
 import type {Customer} from '@shopify/hydrogen/customer-account-api-types';
 
-import {AnalyticsEvent} from '../constants';
+import {AnalyticsEvent, SEARCH_RESULTS_LIST} from '../constants';
 
 import {
   flattenConnection,
@@ -264,6 +264,29 @@ const viewCollectionEvent = ({
   }
 };
 
+// See the note in FueledEvents/events.ts — Hydrogen's `Analytics.SearchView`
+// publishes on mount, so the count follows render behavior (StrictMode in dev,
+// consent resolving, remounts) rather than user intent. Collapse repeats of the
+// same term on the same surface, keyed by term *and* list so the drawer and
+// /search stay separate signals.
+const SEARCH_DEDUPE_MS = 1000;
+let lastSearch: {key: string; at: number} | null = null;
+
+const isDuplicateSearch = (searchTerm: string, list: string) => {
+  const now = Date.now();
+  const key = `${searchTerm}|${list}`;
+  const previous = lastSearch;
+  if (
+    previous &&
+    previous.key === key &&
+    now - previous.at < SEARCH_DEDUPE_MS
+  ) {
+    return true;
+  }
+  lastSearch = {key, at: now};
+  return false;
+};
+
 const viewSearchResultsEvent = ({
   debug,
   ...data
@@ -273,10 +296,19 @@ const viewSearchResultsEvent = ({
     if (debug) logSubscription({data, analyticsEvent});
 
     const {searchResults, searchTerm, customer, shop} = data;
-    if (!searchResults || !searchTerm)
+    if (!searchResults || !searchTerm || !searchResults.length)
       throw new Error(
         '`searchTerm` and/or `searchResults` parameters are missing.',
       );
+
+    const list = data.customData?.list || SEARCH_RESULTS_LIST;
+    if (isDuplicateSearch(searchTerm, list)) {
+      if (debug)
+        console.log(
+          `${ANALYTICS_NAME}: ⏭️ skipped duplicate \`${analyticsEvent}\` for "${searchTerm}" (${list})`,
+        );
+      return;
+    }
 
     const event = {
       event: 'dl_view_search_results',
@@ -286,10 +318,10 @@ const viewSearchResultsEvent = ({
           flattenConnection(searchResults[0]?.variants)?.[0]?.price
             ?.currencyCode || shop?.currency,
         actionField: {
-          list: 'search results',
+          list,
           search_term: searchTerm,
         },
-        impressions: searchResults.slice(0, 7).map(mapProductItemProduct()),
+        impressions: searchResults.slice(0, 7).map(mapProductItemProduct(list)),
       },
     };
     // Elevar requires a `dl_user_data` event before `dl_view_search_results`

--- a/app/components/Analytics/FueledEvents/events.ts
+++ b/app/components/Analytics/FueledEvents/events.ts
@@ -1,6 +1,6 @@
 import type {Customer} from '@shopify/hydrogen/customer-account-api-types';
 
-import {AnalyticsEvent} from '../constants';
+import {AnalyticsEvent, SEARCH_RESULTS_LIST} from '../constants';
 
 import {
   flattenConnection,
@@ -265,6 +265,31 @@ const viewCollectionEvent = ({
   }
 };
 
+// Hydrogen's `Analytics.SearchView` publishes from a `useEffect` keyed on
+// `[publish, url, shop?.shopId]`, so the event count follows component mount
+// timing rather than user intent: twice under React StrictMode in dev, again
+// when `publish` swaps from a no-op to the real function as consent resolves,
+// and again on any remount. Collapse repeats of the same term on the same
+// surface inside a short window so the count can't drift with render behavior.
+// Keyed by term *and* list so the drawer and /search stay separate signals.
+const SEARCH_DEDUPE_MS = 1000;
+let lastSearch: {key: string; at: number} | null = null;
+
+const isDuplicateSearch = (searchTerm: string, list: string) => {
+  const now = Date.now();
+  const key = `${searchTerm}|${list}`;
+  const previous = lastSearch;
+  if (
+    previous &&
+    previous.key === key &&
+    now - previous.at < SEARCH_DEDUPE_MS
+  ) {
+    return true;
+  }
+  lastSearch = {key, at: now};
+  return false;
+};
+
 const viewSearchResultsEvent = ({
   debug,
   ...data
@@ -274,10 +299,19 @@ const viewSearchResultsEvent = ({
     if (debug) logSubscription({data, analyticsEvent});
 
     const {searchResults, searchTerm, customer, shop} = data;
-    if (!searchResults || !searchTerm)
+    if (!searchResults || !searchTerm || !searchResults.length)
       throw new Error(
         '`searchTerm` and/or `searchResults` parameters are missing.',
       );
+
+    const list = data.customData?.list || SEARCH_RESULTS_LIST;
+    if (isDuplicateSearch(searchTerm, list)) {
+      if (debug)
+        console.log(
+          `${ANALYTICS_NAME}: ⏭️ skipped duplicate \`${analyticsEvent}\` for "${searchTerm}" (${list})`,
+        );
+      return;
+    }
 
     const event = {
       event: 'dl_view_search_results',
@@ -287,10 +321,10 @@ const viewSearchResultsEvent = ({
           flattenConnection(searchResults[0]?.variants)?.[0]?.price
             ?.currencyCode || shop?.currency,
         actionField: {
-          list: 'search results',
+          list,
           search_term: searchTerm,
         },
-        products: searchResults.slice(0, 12).map(mapProductItemProduct()),
+        products: searchResults.slice(0, 12).map(mapProductItemProduct(list)),
       },
     };
     dispatchEvent({event, debug});

--- a/app/components/Analytics/GA4Events/events.ts
+++ b/app/components/Analytics/GA4Events/events.ts
@@ -1,6 +1,6 @@
 import type {Customer} from '@shopify/hydrogen/customer-account-api-types';
 
-import {AnalyticsEvent} from '../constants';
+import {AnalyticsEvent, SEARCH_RESULTS_LIST} from '../constants';
 
 import {
   flattenConnection,
@@ -269,6 +269,29 @@ const viewCollectionEvent = ({
   }
 };
 
+// See the note in FueledEvents/events.ts — Hydrogen's `Analytics.SearchView`
+// publishes on mount, so the count follows render behavior (StrictMode in dev,
+// consent resolving, remounts) rather than user intent. Collapse repeats of the
+// same term on the same surface, keyed by term *and* list so the drawer and
+// /search stay separate signals.
+const SEARCH_DEDUPE_MS = 1000;
+let lastSearch: {key: string; at: number} | null = null;
+
+const isDuplicateSearch = (searchTerm: string, list: string) => {
+  const now = Date.now();
+  const key = `${searchTerm}|${list}`;
+  const previous = lastSearch;
+  if (
+    previous &&
+    previous.key === key &&
+    now - previous.at < SEARCH_DEDUPE_MS
+  ) {
+    return true;
+  }
+  lastSearch = {key, at: now};
+  return false;
+};
+
 const viewSearchResultsEvent = ({
   debug,
   ...data
@@ -278,10 +301,19 @@ const viewSearchResultsEvent = ({
     if (debug) logSubscription({data, analyticsEvent});
 
     const {searchResults, searchTerm, customer, shop} = data;
-    if (!searchResults || !searchTerm)
+    if (!searchResults || !searchTerm || !searchResults.length)
       throw new Error(
         '`searchTerm` and/or `searchResults` parameters are missing.',
       );
+
+    const list = data.customData?.list || SEARCH_RESULTS_LIST;
+    if (isDuplicateSearch(searchTerm, list)) {
+      if (debug)
+        console.log(
+          `${ANALYTICS_NAME}: ⏭️ skipped duplicate \`${analyticsEvent}\` for "${searchTerm}" (${list})`,
+        );
+      return;
+    }
 
     const event = {
       event: 'view_search_results',
@@ -291,10 +323,10 @@ const viewSearchResultsEvent = ({
           flattenConnection(searchResults[0]?.variants)?.[0]?.price
             ?.currencyCode || shop?.currency,
         actionField: {
-          list: 'search results',
+          list,
           search_term: searchTerm,
         },
-        products: searchResults.slice(0, 12).map(mapProductItemProduct()),
+        products: searchResults.slice(0, 12).map(mapProductItemProduct(list)),
       },
     };
     emitEvent({event, debug});

--- a/app/components/Analytics/constants.ts
+++ b/app/components/Analytics/constants.ts
@@ -11,6 +11,13 @@ import {AnalyticsEvent as HydrogenAnalyticsEvent} from '@shopify/hydrogen';
 // PRODUCT_REMOVED_FROM_CART: "product_removed_from_cart";
 // CUSTOM_EVENT: `custom_${string}`;
 
+// `actionField.list` values for the two search surfaces. They publish the same
+// `SEARCH_VIEWED` event, so these are what let downstream tell "a shopper
+// searched" (typeahead drawer) apart from "a shopper opened full results"
+// (/search route) instead of summing them as one metric.
+export const SEARCH_RESULTS_LIST = 'search results';
+export const PREDICTIVE_SEARCH_LIST = 'predictive search results';
+
 export const AnalyticsEvent = {
   ...HydrogenAnalyticsEvent,
   PRODUCT_VARIANT_SELECTED: 'custom_product_variant_selected',

--- a/app/components/Search/Search.tsx
+++ b/app/components/Search/Search.tsx
@@ -54,7 +54,6 @@ export const Search = memo(() => {
         <SearchSuggestions
           handleSuggestion={handleSuggestion}
           hasNoProductResults={hasNoProductResults}
-          searchTerm={searchTerm}
         />
       )}
 

--- a/app/components/Search/SearchResults.tsx
+++ b/app/components/Search/SearchResults.tsx
@@ -1,5 +1,3 @@
-import {Analytics} from '@shopify/hydrogen';
-
 import {Link} from '~/components/Link';
 import {useSettings} from '~/hooks';
 
@@ -60,14 +58,10 @@ export function SearchResults({
         </div>
       )}
 
-      {searchTerm && !!productResults?.length && (
-        <Analytics.SearchView
-          data={{
-            searchTerm,
-            searchResults: productResults,
-          }}
-        />
-      )}
+      {/* No `Analytics.SearchView` here on purpose. `search_viewed` is
+      published once, from the /search route, when the user commits to a search
+      (clicks the results link or presses Enter). Publishing it from the
+      predictive drawer too produced two events per search. */}
     </div>
   );
 }

--- a/app/components/Search/SearchResults.tsx
+++ b/app/components/Search/SearchResults.tsx
@@ -1,4 +1,7 @@
+import {Analytics} from '@shopify/hydrogen';
+
 import {Link} from '~/components/Link';
+import {PREDICTIVE_SEARCH_LIST} from '~/components/Analytics/constants';
 import {useSettings} from '~/hooks';
 
 import {SearchItem} from './SearchItem';
@@ -48,7 +51,11 @@ export function SearchResults({
             {collectionResults.map(({handle, title}, index) => {
               return (
                 <li key={index}>
-                  <Link aria-label={title} href={`/collections/${handle}`}>
+                  <Link
+                    aria-label={title}
+                    href={`/collections/${handle}`}
+                    onClick={closeSearch}
+                  >
                     <p className="text-underline">{title}</p>
                   </Link>
                 </li>
@@ -58,10 +65,19 @@ export function SearchResults({
         </div>
       )}
 
-      {/* No `Analytics.SearchView` here on purpose. `search_viewed` is
-      published once, from the /search route, when the user commits to a search
-      (clicks the results link or presses Enter). Publishing it from the
-      predictive drawer too produced two events per search. */}
+      {/* The drawer and the /search route are two distinct signals: "a shopper
+      searched" versus "a shopper opened full results". They're tagged with
+      different `list` values so downstream can count them separately instead of
+      summing them as one metric. */}
+      {searchTerm && !!productResults?.length && (
+        <Analytics.SearchView
+          data={{
+            searchTerm,
+            searchResults: productResults,
+          }}
+          customData={{list: PREDICTIVE_SEARCH_LIST}}
+        />
+      )}
     </div>
   );
 }

--- a/app/components/Search/SearchSuggestions.tsx
+++ b/app/components/Search/SearchSuggestions.tsx
@@ -1,5 +1,3 @@
-import {Analytics} from '@shopify/hydrogen';
-
 import {useSettings} from '~/hooks';
 
 import type {SearchSuggestionsProps} from './Search.types';
@@ -7,24 +5,16 @@ import type {SearchSuggestionsProps} from './Search.types';
 export function SearchSuggestions({
   handleSuggestion,
   hasNoProductResults,
-  searchTerm,
 }: SearchSuggestionsProps) {
   const {search} = useSettings();
-  const {results, suggestions, input} = {...search};
+  const {results, suggestions} = {...search};
   const {noResultsText} = {...results};
   const {heading, terms} = {...suggestions};
-  const characterMin = Number(input?.characterMin || 1);
 
   return (
     <div className="scrollbar-hide flex flex-1 flex-col gap-8 overflow-y-auto p-8">
       {hasNoProductResults && (
-        <>
-          <h3 className="text-base font-normal">{noResultsText}</h3>
-
-          {searchTerm?.length >= characterMin && (
-            <Analytics.SearchView data={{searchTerm, searchResults: []}} />
-          )}
-        </>
+        <h3 className="text-base font-normal">{noResultsText}</h3>
       )}
 
       {terms?.length > 0 && (

--- a/app/components/Search/search.types.ts
+++ b/app/components/Search/search.types.ts
@@ -36,5 +36,4 @@ export interface SearchResultsProps {
 export interface SearchSuggestionsProps {
   handleSuggestion: HandleSuggestion;
   hasNoProductResults: boolean;
-  searchTerm: string;
 }

--- a/app/routes/($locale).search.tsx
+++ b/app/routes/($locale).search.tsx
@@ -12,6 +12,7 @@ import type {
 } from '@shopify/hydrogen/storefront-api-types';
 
 import {Collection} from '~/components/Collection';
+import {SEARCH_RESULTS_LIST} from '~/components/Analytics/constants';
 import {PRODUCTS_SEARCH_QUERY} from '~/data/graphql/storefront/search';
 import {getFilters} from '~/lib/server-utils/collection.server';
 import {getShop, getSiteSettings} from '~/lib/server-utils/settings.server';
@@ -165,6 +166,7 @@ export default function SearchRoute() {
             searchTerm,
             searchResults: collection.products.nodes,
           }}
+          customData={{list: SEARCH_RESULTS_LIST}}
         />
       )}
     </section>


### PR DESCRIPTION
## Problem

The predictive search drawer and the `/search` route both publish `SEARCH_VIEWED`, and both tagged it with an identical `actionField.list` of `'search results'`. Nothing downstream could tell them apart, so a single shopper search summed as two identical events. Reported by Enso Rings via Fueled QA.

Every subscribed integration is affected — `ElevarEvents` and `GA4Events` are env-enabled here, `FueledEvents` wherever a client turns it on.

## Why not just delete one

That was this PR's first approach, and it was wrong. The two events describe **different behaviors**:

- **drawer** — a shopper searched and saw typeahead results. Many never go further; they click a product straight from the dropdown.
- **`/search`** — a shopper opened full results. It's also the *only* one that fires for direct `/search?q=` landings from bookmarks, email, or organic search.

Deleting either one throws away a real signal for every Pack client. Blueprint shouldn't hardcode that product decision — it should ship a default that doesn't double-count and let clients choose.

## Fix

**Label the surfaces.** New `SEARCH_RESULTS_LIST` and `PREDICTIVE_SEARCH_LIST` constants, applied per surface via `customData`. `list` also flows into `mapProductItemProduct` so per-product attribution matches where the impression came from. Downstream can now count them separately or together — their choice, not ours.

**Make the handler idempotent.** A 1s dedupe guard in all three vendor handlers, keyed on term *and* list. Hydrogen's `AnalyticsView` publishes from an effect keyed on `[publish, url, shop?.shopId]`, so the count tracks mount timing rather than user intent:

```js
useEffect(() => {
  if (!shop?.shopId) return;
  publish(type, viewPayload);
}, [publish, url, shop?.shopId]);
```

It fires twice under React StrictMode in dev, again when `publish` swaps from a no-op to the real function as consent resolves, and again on any remount. Keying by `list` collapses accidental repeats of one surface while keeping the two surfaces distinct. **This is the piece that stops the whack-a-mole** — three previous attempts each closed one mount pathway and missed others.

**Two real bugs found along the way:**

- `SearchSuggestions` published a products-less search event on zero-result terms. The handlers only checked `!searchResults`, and `[]` is truthy, so Blueprint emitted an empty `dl_view_search_results`. Removed the publish and guarded the handlers.
- Collection suggestions in the drawer had no `onClick`, and nothing closes the search drawer on navigation. Clicking one left the drawer's `SearchView` mounted through the route change, so it re-published on the `url` dep. Product links already called `closeSearch`; collection links now match.

All three handlers changed together — they share one pipeline, so letting them drift apart is how this class of bug survives.

## Verification

- `npm ci` clean
- `npm run typecheck` — 112 errors, identical set to `main` (only line numbers shift from an added import)
- `npx eslint` + `prettier --check` on all changed files — zero problems
- `npm run build` — exit 0, no new warnings
- Server bundle imports without error

**Not verified in a browser.** Note that `npm run dev` is the wrong place to QA this: StrictMode double-invokes effects in development, so *every* view event fires twice there regardless of this fix. Verify against `npm run preview` (production bundle) with:

```js
window.__se = [];
window.addEventListener('dl_view_search_results', (e) => {
  window.__se.push(e.detail);
  console.log(`#${window.__se.length}`, e.detail.ecommerce?.actionField?.list, e.detail.event_id);
});
```

Expected: one event tagged `predictive search results` when typeahead results appear, one tagged `search results` on click-through, and no repeats of either.

## Related, not fixed here

`FueledEvents`, `GA4Events`, and `ElevarEvents` all call `register()` during render while resolving `ready()` only inside an effect — and GA4/Elevar gate `ready()` behind their vendor script loading. Hydrogen's `publish()` queues every event into `waitForReadyQueue` until *all* registrants are ready, so one blocked vendor script silently drops all analytics. Missing-events failure mode, structurally different, needs its own PR and QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)