### PR TITLE
Add CLAUDE.md marking Blueprint as a public repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# CLAUDE.md — pack-hydrogen-theme-blueprint
+
+## This is a PUBLIC repo
+
+This repository is public on GitHub. Anything committed here — code, comments, commit messages, PR titles and descriptions, review comments, docs, issue references — is world-readable and permanent.
+
+Treat every artifact you produce in this repo as if it will be indexed by search engines and read by clients, competitors, and prospects.
+
+## Never include in this repo
+
+- **Client / customer / merchant names, brand names, domains, URLs, handles, storefront references** — not in code, not in comments, not in commit messages, not in PR bodies, not in docs
+- **Pack account tiers, deal sizes, ARR, MRR, contract terms, or any internal business context**
+- **Names of internal-only Pack repos, tools, agents, or infrastructure paths** (e.g., `pack-support-agents/`, internal Slack channels, Linear/Asana identifiers)
+- **Log excerpts, screenshots, or configuration** that could contain customer-identifying data
+- **Content sourced from a Pack Slack channel, Linear issue, Asana task, or any internal doc**
+
+## Instead
+
+When a fix originates from a specific storefront's failure, describe the **failure mode** in generic terms. Cite the storefront and the internal context in the **Linear issue** that tracks the PR — never in the PR itself, and never in the commit history.
+
+Example:
+- ❌ "Seen on brandname.com — Google was showing 'Application Error'"
+- ✅ "Observed in production when a crawler indexed a transient render failure"
+
+## If you already leaked
+
+- If the branch is fresh and no one has interacted with it: `git commit --amend`, `git push --force-with-lease`, and edit the PR body via `gh pr edit`
+- If the commit has been pulled or reviewed: escalate to the human owner before rewriting history
+- Do not leave it in place hoping no one notices
+
+## When in doubt
+
+Don't include it. Ask.


### PR DESCRIPTION
## Summary

Blueprint is a public GitHub repo, but nothing in the repo names that fact for new contributors or AI coding assistants. This adds a `CLAUDE.md` at the repo root stating the rule plainly:

- No client / customer / merchant names, domains, or storefront references — anywhere in code, comments, commit messages, PR bodies, or docs
- No Pack account tiers, deal sizes, or internal business context
- No references to internal-only Pack repos or tools
- No log excerpts, screenshots, or config that could contain customer-identifying data
- Where internal context DOES go (the tracking Linear/Asana issue, not the PR)

Also includes a short "if you already leaked" section so a fresh mistake gets fixed the same way (amend, force-push-with-lease, edit the PR body) rather than left in place.

## Why

`CLAUDE.md` is the Claude Code convention for repo-specific instructions — it loads automatically for any Claude session in the repo, so this guardrail applies to every AI-assisted contribution going forward. It doubles as a plain-English README-adjacent doc for human contributors.

## Test plan

- [x] Content review — no code changes, no build impact
- [ ] Approver confirms the rule matches how Blueprint should be treated

🤖 Generated with [Claude Code](https://claude.com/claude-code)